### PR TITLE
fix: normalize FreshRSS proxied favicon urls

### DIFF
--- a/app/src/androidTest/java/me/ash/reader/FreshRssSyncE2eTest.kt
+++ b/app/src/androidTest/java/me/ash/reader/FreshRssSyncE2eTest.kt
@@ -141,6 +141,63 @@ class FreshRssSyncE2eTest {
         )
     }
 
+    @Test
+    fun sync_rewrites_proxied_icon_urls_to_the_configured_freshrss_host() {
+        dispatcher.subscriptionIconUrl = "http://192.168.107.2/f.php?h=feed-icon"
+        val accountId = seedFreshRssAccount()
+
+        launchApp()
+        pullToSyncFromFlow()
+
+        val expectedIconUrl = server.url("/f.php?h=feed-icon").toString()
+        assertTrue(
+            "Expected synced feed icon to be normalized to $expectedIconUrl",
+            waitForCondition(15_000) {
+                runBlocking {
+                    database.feedDao().queryById(accountId.spacerDollar(FEED_ID))?.icon ==
+                        expectedIconUrl
+                }
+            },
+        )
+    }
+
+    @Test
+    fun app_start_repairs_stored_proxied_icon_urls_to_the_configured_freshrss_host() {
+        val accountId = seedFreshRssAccount()
+        val feedId = accountId.spacerDollar(FEED_ID)
+        val oldIconUrl = "http://192.168.107.2/f.php?h=stored-icon"
+        val expectedIconUrl = server.url("/f.php?h=stored-icon").toString()
+
+        runBlocking {
+            database.groupDao().insert(
+                Group(
+                    id = accountId.getDefaultGroupId(),
+                    name = "Defaults",
+                    accountId = accountId,
+                ),
+            )
+            database.feedDao().insert(
+                Feed(
+                    id = feedId,
+                    name = "Stored Feed",
+                    url = "https://example.com/feed",
+                    groupId = accountId.getDefaultGroupId(),
+                    accountId = accountId,
+                    icon = oldIconUrl,
+                ),
+            )
+        }
+
+        launchApp()
+
+        assertTrue(
+            "Expected startup repair to rewrite $oldIconUrl to $expectedIconUrl",
+            waitForCondition(15_000) {
+                runBlocking { database.feedDao().queryById(feedId)?.icon == expectedIconUrl }
+            },
+        )
+    }
+
     @Ignore("Temporarily disabled to unblock CI while the restart flow is unstable.")
     @Test
     fun offline_local_reads_stay_read_after_app_restart_and_sync() {
@@ -251,6 +308,44 @@ class FreshRssSyncE2eTest {
         return SeededArticle(title = title, localArticleId = article.id)
     }
 
+    private fun seedFreshRssAccount(): Int {
+        val accountId =
+            runBlocking {
+                val securityKey =
+                    GoogleReaderSecurityKey(
+                        server.url("/").toString(),
+                        "demo",
+                        "demo",
+                        null,
+                    ).toString()
+                database.accountDao()
+                    .insert(
+                        Account(
+                            name = "FreshRSS E2E",
+                            type = AccountType.FreshRSS,
+                            securityKey = securityKey,
+                        )
+                    )
+                    .toInt()
+            }
+
+        runBlocking {
+            targetContext.dataStore.put(DataStoreKey.isFirstLaunch, false)
+            targetContext.dataStore.put(DataStoreKey.currentAccountId, accountId)
+            targetContext.dataStore.put(DataStoreKey.currentAccountType, AccountType.FreshRSS.id)
+            targetContext.dataStore.put(
+                DataStoreKey.initialPage,
+                InitialPagePreference.FlowPage.value,
+            )
+            targetContext.dataStore.put(
+                DataStoreKey.initialFilter,
+                InitialFilterPreference.Unread.value,
+            )
+        }
+
+        return accountId
+    }
+
     private fun launchApp() {
         val intent =
             Intent(targetContext, MainActivity::class.java).apply {
@@ -335,6 +430,7 @@ class FreshRssSyncE2eTest {
         @Volatile var networkAvailable: Boolean = true
         @Volatile var remoteUnreadIds: Set<String> = emptySet()
         @Volatile var remoteReadIds: Set<String> = emptySet()
+        @Volatile var subscriptionIconUrl: String? = null
 
         override fun dispatch(request: RecordedRequest): MockResponse {
             if (!networkAvailable) {
@@ -353,7 +449,7 @@ class FreshRssSyncE2eTest {
                 "/reader/api/0/subscription/list" ->
                     jsonResponse(
                         """
-                        {"subscriptions":[{"id":"feed/$FEED_ID","title":"E2E Feed","url":"https://example.com/feed","htmlUrl":"https://example.com","iconUrl":null,"sortid":"1"}]}
+                        {"subscriptions":[{"id":"feed/$FEED_ID","title":"E2E Feed","url":"https://example.com/feed","htmlUrl":"https://example.com","iconUrl":${subscriptionIconJson()},"sortid":"1"}]}
                         """.trimIndent()
                     )
 
@@ -395,6 +491,10 @@ class FreshRssSyncE2eTest {
                 .setResponseCode(200)
                 .addHeader("Content-Type", "application/json")
                 .setBody(body)
+        }
+
+        private fun subscriptionIconJson(): String {
+            return subscriptionIconUrl?.let { "\"$it\"" } ?: "null"
         }
     }
 

--- a/app/src/main/java/me/ash/reader/domain/service/AbstractRssRepository.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/AbstractRssRepository.kt
@@ -51,6 +51,8 @@ abstract class AbstractRssRepository(
 
     open suspend fun clearAuthorization() {}
 
+    open suspend fun repairAccountData(accountId: Int) {}
+
     open suspend fun subscribe(
         feedLink: String,
         searchedFeed: SyndFeed,

--- a/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
@@ -1,6 +1,7 @@
 package me.ash.reader.domain.service
 
 import android.content.Context
+import android.net.Uri
 import android.util.Log
 import androidx.compose.ui.util.fastFilter
 import androidx.compose.ui.util.fastFilteredMap
@@ -30,6 +31,7 @@ import me.ash.reader.domain.data.SyncLogger
 import me.ash.reader.domain.model.account.Account
 import me.ash.reader.domain.model.account.AccountType
 import me.ash.reader.domain.model.account.AccountType.Companion.FreshRSS
+import me.ash.reader.domain.model.account.security.FreshRSSSecurityKey
 import me.ash.reader.domain.model.account.security.GoogleReaderSecurityKey
 import me.ash.reader.domain.model.article.Article
 import me.ash.reader.domain.model.feed.Feed
@@ -125,6 +127,25 @@ constructor(
 
     override suspend fun clearAuthorization() {
         GoogleReaderAPI.clearInstance()
+    }
+
+    override suspend fun repairAccountData(accountId: Int) {
+        val account = accountService.getAccountById(accountId) ?: return
+        val normalizedIconBaseUrl = account.normalizedFreshRssIconBaseUrl() ?: return
+        val normalizedFeeds =
+            feedDao.queryAll(accountId)
+                .mapNotNull { feed ->
+                    val normalizedIcon = normalizeFreshRssIconUrl(feed.icon, normalizedIconBaseUrl)
+                    if (normalizedIcon != feed.icon) {
+                        feed.copy(icon = normalizedIcon)
+                    } else {
+                        null
+                    }
+                }
+
+        if (normalizedFeeds.isNotEmpty()) {
+            feedDao.update(*normalizedFeeds.toTypedArray())
+        }
     }
 
     override suspend fun subscribe(
@@ -404,6 +425,8 @@ constructor(
 
             // 2. Fetch folder and subscription list
             val groupWithFeedsMap = async {
+                val currentAccount = requireNotNull(accountService.getAccountById(accountId))
+                val normalizedIconBaseUrl = currentAccount.normalizedFreshRssIconBaseUrl()
                 val subscriptionList = googleReaderAPI.getSubscriptionList()
                 requireNotNull(subscriptionList) { "subscriptionList is null" }
                 subscriptionList.subscriptions
@@ -432,7 +455,7 @@ constructor(
                                 url = feedUrl,
                                 groupId = group.id,
                                 accountId = accountId,
-                                icon = it.iconUrl,
+                                icon = normalizeFreshRssIconUrl(it.iconUrl, normalizedIconBaseUrl),
                             )
                         }
                     }
@@ -903,4 +926,35 @@ constructor(
                 unmark = if (!isStarred) GoogleReaderAPI.Stream.Starred.tag else null,
             )
     }
+}
+private fun Account.normalizedFreshRssIconBaseUrl(): Uri? {
+    if (type.id != FreshRSS.id) return null
+    val serverUrl = FreshRSSSecurityKey(securityKey).serverUrl ?: return null
+    val serverUri = Uri.parse(serverUrl)
+    if (serverUri.scheme.isNullOrBlank() || serverUri.encodedAuthority.isNullOrBlank()) return null
+    return serverUri.buildUpon().clearQuery().fragment(null).path(null).build()
+}
+
+private fun normalizeFreshRssIconUrl(iconUrl: String?, normalizedIconBaseUrl: Uri?): String? {
+    if (iconUrl.isNullOrBlank() || normalizedIconBaseUrl == null) return iconUrl
+
+    val iconUri = Uri.parse(iconUrl)
+    val path = iconUri.path ?: return iconUrl
+    if (!path.startsWith("/f.php")) return iconUrl
+
+    val iconAuthority = iconUri.encodedAuthority
+    val iconScheme = iconUri.scheme
+    if (
+        iconScheme == normalizedIconBaseUrl.scheme &&
+            iconAuthority == normalizedIconBaseUrl.encodedAuthority
+    ) {
+        return iconUrl
+    }
+
+    return iconUri
+        .buildUpon()
+        .scheme(normalizedIconBaseUrl.scheme)
+        .encodedAuthority(normalizedIconBaseUrl.encodedAuthority)
+        .build()
+        .toString()
 }

--- a/app/src/main/java/me/ash/reader/infrastructure/android/AndroidApp.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/android/AndroidApp.kt
@@ -102,6 +102,7 @@ class AndroidApp : Application(), Configuration.Provider {
         }
         applicationScope.launch {
             accountInit()
+            repairCurrentAccountData()
             workerInit()
             checkUpdate()
         }
@@ -130,6 +131,13 @@ class AndroidApp : Application(), Configuration.Provider {
 
     private suspend fun workerInit() {
         rssService.get().initSync()
+    }
+
+    private suspend fun repairCurrentAccountData() {
+        withContext(ioDispatcher) {
+            val account = accountService.getCurrentAccount()
+            rssService.get(account.type.id).repairAccountData(account.id!!)
+        }
     }
 
     private suspend fun checkUpdate() {

--- a/app/src/main/java/me/ash/reader/infrastructure/coil/IcoDecoder.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/coil/IcoDecoder.kt
@@ -84,10 +84,10 @@ private data class IconDirEntry(
     val offset: Int,
 ) {
     val widthPixels: Int
-        get() = width.toInt().takeUnless { it == 0 } ?: 256
+        get() = width.toUnsignedDimension()
 
     val heightPixels: Int
-        get() = height.toInt().takeUnless { it == 0 } ?: 256
+        get() = height.toUnsignedDimension()
 }
 
 private fun isIco(source: BufferedSource): Boolean {
@@ -171,3 +171,8 @@ private fun ByteArray.hasPngHeader(): Boolean =
         this[1] == 0x50.toByte() &&
         this[2] == 0x4E.toByte() &&
         this[3] == 0x47.toByte()
+
+private fun Byte.toUnsignedDimension(): Int {
+    val value = toInt() and 0xFF
+    return if (value == 0) 256 else value
+}

--- a/app/src/main/java/me/ash/reader/infrastructure/coil/IcoDecoder.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/coil/IcoDecoder.kt
@@ -58,10 +58,6 @@ class IcoDecoder(
             options: Options,
             imageLoader: ImageLoader,
         ): Decoder? {
-            val mimeType = result.mimeType
-            if (mimeType != null && mimeType.contains("icon", ignoreCase = true)) {
-                return IcoDecoder(result, options)
-            }
             return if (isIco(result.source.source().peek())) {
                 IcoDecoder(result, options)
             } else {

--- a/app/src/main/java/me/ash/reader/infrastructure/coil/IcoDecoder.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/coil/IcoDecoder.kt
@@ -1,0 +1,173 @@
+package me.ash.reader.infrastructure.coil
+import android.graphics.BitmapFactory
+import android.graphics.drawable.BitmapDrawable
+import coil.ImageLoader
+import coil.decode.DecodeResult
+import coil.decode.Decoder
+import coil.fetch.SourceResult
+import coil.request.Options
+import coil.size.Dimension
+import coil.size.Size
+import okio.BufferedSource
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+
+/**
+ * Decodes ICO favicons served by FreshRSS proxy endpoints.
+ */
+class IcoDecoder(
+    private val sourceResult: SourceResult,
+    private val options: Options,
+) : Decoder {
+
+    override suspend fun decode(): DecodeResult {
+        val imageSource = sourceResult.source
+        val source = imageSource.source()
+        val image = selectBestEntry(source.peek(), options.size)
+
+        source.skip(image.offset.toLong())
+        val imageBytes = source.readByteArray(image.size.toLong())
+        val decodeBytes =
+            if (imageBytes.hasPngHeader()) {
+                imageBytes
+            } else {
+                buildSingleEntryIco(image, imageBytes)
+            }
+
+        val bitmap =
+            requireNotNull(
+                BitmapFactory.decodeByteArray(
+                    decodeBytes,
+                    0,
+                    decodeBytes.size,
+                    BitmapFactory.Options().apply {
+                        inPreferredConfig = options.config
+                    },
+                )
+            ) { "Failed to decode ICO image" }
+
+        return DecodeResult(
+            drawable = BitmapDrawable(options.context.resources, bitmap),
+            isSampled = false,
+        )
+    }
+
+    class Factory : Decoder.Factory {
+        override fun create(
+            result: SourceResult,
+            options: Options,
+            imageLoader: ImageLoader,
+        ): Decoder? {
+            val mimeType = result.mimeType
+            if (mimeType != null && mimeType.contains("icon", ignoreCase = true)) {
+                return IcoDecoder(result, options)
+            }
+            return if (isIco(result.source.source().peek())) {
+                IcoDecoder(result, options)
+            } else {
+                null
+            }
+        }
+    }
+}
+
+private const val ICO_HEADER_SIZE = 6
+private const val ICO_ENTRY_SIZE = 16
+
+private data class IconDirEntry(
+    val width: Byte,
+    val height: Byte,
+    val numColors: Byte,
+    val colorPlanes: Short,
+    val bytesPerPixel: Short,
+    val size: Int,
+    val offset: Int,
+) {
+    val widthPixels: Int
+        get() = width.toInt().takeUnless { it == 0 } ?: 256
+
+    val heightPixels: Int
+        get() = height.toInt().takeUnless { it == 0 } ?: 256
+}
+
+private fun isIco(source: BufferedSource): Boolean {
+    val peek = source.peek()
+    return runCatching {
+        peek.readShortLe() == 0.toShort() &&
+            peek.readShortLe() == 1.toShort() &&
+            peek.readShortLe().toInt() in 1..256
+    }.getOrDefault(false)
+}
+
+private fun selectBestEntry(
+    source: BufferedSource,
+    preferredSize: Size,
+): IconDirEntry {
+    val peek = source.peek()
+    peek.skip(4)
+    val numImages = peek.readShortLe().toInt()
+    var image = parseEntry(peek)
+    val preferredWidth = (preferredSize.width as? Dimension.Pixels)?.px
+    val preferredHeight = (preferredSize.height as? Dimension.Pixels)?.px
+
+    repeat(numImages - 1) {
+        if (
+            preferredWidth != null &&
+                preferredHeight != null &&
+                image.widthPixels >= preferredWidth &&
+                image.heightPixels >= preferredHeight
+        ) {
+            return image
+        }
+
+        val currentImage = parseEntry(peek)
+        if (currentImage.widthPixels * currentImage.heightPixels >
+            image.widthPixels * image.heightPixels
+        ) {
+            image = currentImage
+        }
+    }
+
+    return image
+}
+
+private fun parseEntry(source: BufferedSource): IconDirEntry {
+    val width = source.readByte()
+    val height = source.readByte()
+    val numColors = source.readByte()
+    source.skip(1)
+    val colorPlanes = source.readShortLe()
+    val bytesPerPixel = source.readShortLe()
+    val size = source.readIntLe()
+    val offset = source.readIntLe()
+    return IconDirEntry(width, height, numColors, colorPlanes, bytesPerPixel, size, offset)
+}
+
+private fun buildSingleEntryIco(
+    image: IconDirEntry,
+    imageBytes: ByteArray,
+): ByteArray =
+    ByteBuffer
+        .wrap(ByteArray(ICO_HEADER_SIZE + ICO_ENTRY_SIZE + image.size))
+        .apply {
+            order(ByteOrder.LITTLE_ENDIAN)
+            putShort(0)
+            putShort(1)
+            putShort(1)
+            put(image.width)
+            put(image.height)
+            put(image.numColors)
+            put(0)
+            putShort(image.colorPlanes)
+            putShort(image.bytesPerPixel)
+            putInt(image.size)
+            putInt(ICO_HEADER_SIZE + ICO_ENTRY_SIZE)
+            put(imageBytes)
+        }.array()
+
+private fun ByteArray.hasPngHeader(): Boolean =
+    size > 4 &&
+        this[0] == 0x89.toByte() &&
+        this[1] == 0x50.toByte() &&
+        this[2] == 0x4E.toByte() &&
+        this[3] == 0x47.toByte()

--- a/app/src/main/java/me/ash/reader/infrastructure/coil/IcoDecoder.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/coil/IcoDecoder.kt
@@ -9,8 +9,6 @@ import coil.request.Options
 import coil.size.Dimension
 import coil.size.Size
 import okio.BufferedSource
-import java.nio.ByteBuffer
-import java.nio.ByteOrder
 
 /**
  * Decodes ICO favicons served by FreshRSS proxy endpoints.
@@ -27,19 +25,13 @@ class IcoDecoder(
 
         source.skip(image.offset.toLong())
         val imageBytes = source.readByteArray(image.size.toLong())
-        val decodeBytes =
-            if (imageBytes.hasPngHeader()) {
-                imageBytes
-            } else {
-                buildSingleEntryIco(image, imageBytes)
-            }
 
         val bitmap =
             requireNotNull(
                 BitmapFactory.decodeByteArray(
-                    decodeBytes,
+                    imageBytes,
                     0,
-                    decodeBytes.size,
+                    imageBytes.size,
                     BitmapFactory.Options().apply {
                         inPreferredConfig = options.config
                     },
@@ -58,7 +50,8 @@ class IcoDecoder(
             options: Options,
             imageLoader: ImageLoader,
         ): Decoder? {
-            return if (isIco(result.source.source().peek())) {
+            val source = result.source.source().peek()
+            return if (supportsDecode(source, options.size)) {
                 IcoDecoder(result, options)
             } else {
                 null
@@ -66,9 +59,6 @@ class IcoDecoder(
         }
     }
 }
-
-private const val ICO_HEADER_SIZE = 6
-private const val ICO_ENTRY_SIZE = 16
 
 private data class IconDirEntry(
     val width: Byte,
@@ -92,6 +82,22 @@ private fun isIco(source: BufferedSource): Boolean {
         peek.readShortLe() == 0.toShort() &&
             peek.readShortLe() == 1.toShort() &&
             peek.readShortLe().toInt() in 1..256
+    }.getOrDefault(false)
+}
+
+private fun supportsDecode(
+    source: BufferedSource,
+    preferredSize: Size,
+): Boolean {
+    if (!isIco(source)) return false
+
+    return runCatching {
+        val peek = source.peek()
+        val image = selectBestEntry(peek, preferredSize)
+        peek.skip(image.offset.toLong())
+        // We only claim ICO payloads when the selected entry is PNG. BMP/DIB entries are left to
+        // Coil's normal failure path so ReadYou avoids crashing on unsupported ICO variants.
+        peek.readByteArray(image.size.toLong()).hasPngHeader()
     }.getOrDefault(false)
 }
 
@@ -138,28 +144,6 @@ private fun parseEntry(source: BufferedSource): IconDirEntry {
     val offset = source.readIntLe()
     return IconDirEntry(width, height, numColors, colorPlanes, bytesPerPixel, size, offset)
 }
-
-private fun buildSingleEntryIco(
-    image: IconDirEntry,
-    imageBytes: ByteArray,
-): ByteArray =
-    ByteBuffer
-        .wrap(ByteArray(ICO_HEADER_SIZE + ICO_ENTRY_SIZE + image.size))
-        .apply {
-            order(ByteOrder.LITTLE_ENDIAN)
-            putShort(0)
-            putShort(1)
-            putShort(1)
-            put(image.width)
-            put(image.height)
-            put(image.numColors)
-            put(0)
-            putShort(image.colorPlanes)
-            putShort(image.bytesPerPixel)
-            putInt(image.size)
-            putInt(ICO_HEADER_SIZE + ICO_ENTRY_SIZE)
-            put(imageBytes)
-        }.array()
 
 private fun ByteArray.hasPngHeader(): Boolean =
     size > 4 &&

--- a/app/src/main/java/me/ash/reader/infrastructure/di/ImageLoaderModule.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/di/ImageLoaderModule.kt
@@ -15,6 +15,7 @@ import dagger.hilt.InstallIn
 import dagger.hilt.android.qualifiers.ApplicationContext
 import dagger.hilt.components.SingletonComponent
 import kotlinx.coroutines.Dispatchers
+import me.ash.reader.infrastructure.coil.IcoDecoder
 import okhttp3.OkHttpClient
 import javax.inject.Singleton
 
@@ -37,6 +38,7 @@ object ImageLoaderModule {
             // This slightly improves scrolling performance
             .dispatcher(Dispatchers.Default)
             .components {
+                add(IcoDecoder.Factory())
                 // Support SVG decoding
                 add(SvgDecoder.Factory())
                 // Support GIF decoding

--- a/app/src/main/java/me/ash/reader/ui/component/base/RYAsyncImage.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/base/RYAsyncImage.kt
@@ -1,5 +1,4 @@
 package me.ash.reader.ui.component.base
-
 import androidx.annotation.DrawableRes
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
@@ -14,6 +13,7 @@ import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.platform.LocalContext
 import coil.compose.rememberAsyncImagePainter
+import coil.imageLoader
 import coil.request.ImageRequest
 import coil.size.Precision
 import coil.size.Scale
@@ -34,10 +34,12 @@ fun RYAsyncImage(
     @DrawableRes placeholder: Int? = null,
     @DrawableRes error: Int? = null,
 ) {
+    val context = LocalContext.current
     val painter =
         rememberAsyncImagePainter(
+            imageLoader = context.imageLoader,
             model =
-                ImageRequest.Builder(LocalContext.current)
+                ImageRequest.Builder(context)
                     .apply {
                         val domain = data.toString().extractDomain()
                         if (data.toString().extractDomain() != null) {


### PR DESCRIPTION
## Summary
- add regression coverage for FreshRSS proxied favicon URLs using the wrong host
- normalize FreshRSS `/f.php` favicon URLs to the configured FreshRSS server during sync
- repair previously stored proxied favicon URLs on app startup and support ICO favicons

fix #6