### PR TITLE
fix: persist favicon backfill after feed insertion

### DIFF
--- a/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
@@ -954,7 +954,7 @@ internal class DaoSubscriptionStore(
     }
 
     override suspend fun updateFeeds(feeds: List<Feed>) {
-        feedDao.update(*feeds.toTypedArray())
+        feedDao.updateAll(feeds)
     }
 }
 

--- a/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
@@ -920,6 +920,8 @@ internal suspend fun persistRemoteSubscriptions(
     queryIcon: suspend (String) -> String?,
 ) {
     val existingFeedIds = subscriptionStore.existingFeedIds()
+    subscriptionStore.insertOrUpdate(remoteGroups, remoteFeeds)
+
     val feedsWithBackfilledIcons =
         backfillIconsForFeeds(
             feeds = selectNewFeedsMissingIcons(remoteFeeds, existingFeedIds),
@@ -928,7 +930,6 @@ internal suspend fun persistRemoteSubscriptions(
     if (feedsWithBackfilledIcons.isNotEmpty()) {
         subscriptionStore.updateFeeds(feedsWithBackfilledIcons)
     }
-    subscriptionStore.insertOrUpdate(remoteGroups, remoteFeeds)
 }
 
 internal interface SubscriptionStore {

--- a/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
@@ -970,7 +970,11 @@ internal suspend fun backfillIconsForFeeds(
     queryIcon: suspend (String) -> String?,
 ): List<Feed> = coroutineScope {
     feeds
-        .map { feed -> async { feed.copy(icon = queryIcon(feed.url)) } }
+        .map { feed ->
+            async {
+                feed.copy(icon = runCatching { queryIcon(feed.url) }.getOrNull())
+            }
+        }
         .awaitAll()
         .filterNot { it.icon.isNullOrEmpty() }
 }

--- a/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
@@ -479,29 +479,15 @@ constructor(
                     )
                     .toMutableList()
 
-            val remoteGroups = async { groupWithFeedsMap.await().keys.toList() }
-            val remoteFeeds = async { groupWithFeedsMap.await().values.flatten() }
+            val remoteGroupsList = groupWithFeedsMap.await().keys.toList()
+            val remoteFeedsList = groupWithFeedsMap.await().values.flatten()
 
-            // Handle empty icon for feeds
-            launch {
-                val localFeeds = feedDao.queryAll(accountId)
-                val remoteFeeds = remoteFeeds.await()
-                val newFeeds = remoteFeeds.filter { feed -> feed.id !in localFeeds.map { it.id } }
-
-                val feedsWithIconFetched =
-                    newFeeds
-                        .filter { it.icon == null }
-                        .map { feed ->
-                            async { feed.copy(icon = rssHelper.queryRssIconLink(feed.url)) }
-                        }
-                feedsWithIconFetched
-                    .awaitAll()
-                    .filterNot { it.icon.isNullOrEmpty() }
-                    .also { feedDao.update(*it.toTypedArray()) }
-            }
-
-            groupDao.insertOrUpdate(remoteGroups.await())
-            feedDao.insertOrUpdate(remoteFeeds.await())
+            persistRemoteSubscriptions(
+                remoteGroups = remoteGroupsList,
+                remoteFeeds = remoteFeedsList,
+                subscriptionStore = DaoSubscriptionStore(accountId, feedDao, groupDao),
+                queryIcon = { rssHelper.queryRssIconLink(it) },
+            )
 
             val notificationFeeds =
                 feedDao.queryNotificationEnabled(accountId).associateBy { it.id }
@@ -541,11 +527,11 @@ constructor(
             // starred/un-starred
             groupDao
                 .queryAll(accountId)
-                .filter { it.id !in remoteGroups.await().map { group -> group.id } }
+                .filter { it.id !in remoteGroupsList.map { group -> group.id } }
                 .forEach { super.deleteGroup(it, true) }
             feedDao
                 .queryAll(accountId)
-                .filter { it.id !in remoteFeeds.await().map { feed -> feed.id } }
+                .filter { it.id !in remoteFeedsList.map { feed -> feed.id } }
                 .forEach { super.deleteFeed(it, true) }
 
             accountService.update(account.copy(updateAt = Date()))
@@ -927,6 +913,67 @@ constructor(
             )
     }
 }
+internal suspend fun persistRemoteSubscriptions(
+    remoteGroups: List<Group>,
+    remoteFeeds: List<Feed>,
+    subscriptionStore: SubscriptionStore,
+    queryIcon: suspend (String) -> String?,
+) {
+    val existingFeedIds = subscriptionStore.existingFeedIds()
+    val feedsWithBackfilledIcons =
+        backfillIconsForFeeds(
+            feeds = selectNewFeedsMissingIcons(remoteFeeds, existingFeedIds),
+            queryIcon = queryIcon,
+        )
+    if (feedsWithBackfilledIcons.isNotEmpty()) {
+        subscriptionStore.updateFeeds(feedsWithBackfilledIcons)
+    }
+    subscriptionStore.insertOrUpdate(remoteGroups, remoteFeeds)
+}
+
+internal interface SubscriptionStore {
+    suspend fun existingFeedIds(): Set<String>
+
+    suspend fun insertOrUpdate(groups: List<Group>, feeds: List<Feed>)
+
+    suspend fun updateFeeds(feeds: List<Feed>)
+}
+
+internal class DaoSubscriptionStore(
+    private val accountId: Int,
+    private val feedDao: FeedDao,
+    private val groupDao: GroupDao,
+) : SubscriptionStore {
+    override suspend fun existingFeedIds(): Set<String> =
+        feedDao.queryAll(accountId).mapTo(mutableSetOf()) { it.id }
+
+    override suspend fun insertOrUpdate(groups: List<Group>, feeds: List<Feed>) {
+        groupDao.insertOrUpdate(groups)
+        feedDao.insertOrUpdate(feeds)
+    }
+
+    override suspend fun updateFeeds(feeds: List<Feed>) {
+        feedDao.update(*feeds.toTypedArray())
+    }
+}
+
+internal fun selectNewFeedsMissingIcons(
+    remoteFeeds: List<Feed>,
+    existingFeedIds: Set<String>,
+): List<Feed> = remoteFeeds.filter { feed ->
+    feed.id !in existingFeedIds && feed.icon.isNullOrEmpty()
+}
+
+internal suspend fun backfillIconsForFeeds(
+    feeds: List<Feed>,
+    queryIcon: suspend (String) -> String?,
+): List<Feed> = coroutineScope {
+    feeds
+        .map { feed -> async { feed.copy(icon = queryIcon(feed.url)) } }
+        .awaitAll()
+        .filterNot { it.icon.isNullOrEmpty() }
+}
+
 private fun Account.normalizedFreshRssIconBaseUrl(): Uri? {
     if (type.id != FreshRSS.id) return null
     val serverUrl = FreshRSSSecurityKey(securityKey).serverUrl ?: return null

--- a/app/src/test/java/me/ash/reader/domain/service/GoogleReaderRssServiceTest.kt
+++ b/app/src/test/java/me/ash/reader/domain/service/GoogleReaderRssServiceTest.kt
@@ -1,8 +1,12 @@
 package me.ash.reader.domain.service
 
 import kotlinx.coroutines.runBlocking
+import me.ash.reader.domain.model.feed.Feed
+import me.ash.reader.domain.model.group.Group
 import me.ash.reader.infrastructure.rss.provider.greader.GoogleReaderDTO
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
 import org.junit.Assert.fail
 import org.junit.Test
 import org.objenesis.ObjenesisStd
@@ -68,6 +72,64 @@ class GoogleReaderRssServiceTest {
         assertEquals(listOf("first-page", "second-page"), ids)
     }
 
+    @Test
+    fun selectNewFeedsMissingIcons_returns_only_new_feeds_without_icons() {
+        val selected =
+            selectNewFeedsMissingIcons(
+                remoteFeeds =
+                    listOf(
+                        testFeed(id = "1", icon = null),
+                        testFeed(id = "2", icon = "https://example.com/icon.png"),
+                        testFeed(id = "3", icon = ""),
+                    ),
+                existingFeedIds = setOf("3"),
+            )
+
+        assertEquals(listOf(testFeed(id = "1", icon = null)), selected)
+    }
+
+    @Test
+    fun backfillIconsForFeeds_returns_only_feeds_with_successful_icon_lookups() = runBlocking {
+        val result =
+            backfillIconsForFeeds(
+                feeds =
+                    listOf(
+                        testFeed(id = "1", url = "https://one.example/feed"),
+                        testFeed(id = "2", url = "https://two.example/feed"),
+                    ),
+                queryIcon = { url ->
+                    if (url == "https://one.example/feed") "https://one.example/favicon.ico" else null
+                },
+            )
+
+        assertEquals(
+            listOf(testFeed(id = "1", url = "https://one.example/feed", icon = "https://one.example/favicon.ico")),
+            result,
+        )
+    }
+
+    @Test
+    fun persistRemoteSubscriptions_persists_backfilled_icons_after_insert() = runBlocking {
+        val group = Group(id = "1\$Defaults", name = "Defaults", accountId = 1)
+        val feed = testFeed(id = "1\$e2e-feed", groupId = group.id)
+        val subscriptionStore = RecordingSubscriptionStore()
+
+        persistRemoteSubscriptions(
+            remoteGroups = listOf(group),
+            remoteFeeds = listOf(feed),
+            subscriptionStore = subscriptionStore,
+            queryIcon = { "https://example.com/favicon.ico" },
+        )
+
+        val storedFeed = subscriptionStore.savedFeedsById[feed.id]
+        assertNotNull("Expected persisted remote feed", storedFeed)
+        assertFalse(
+            "Expected favicon update to happen after feed insertion, but update ran before insert",
+            subscriptionStore.updatedBeforeInsert,
+        )
+        assertEquals("https://example.com/favicon.ico", storedFeed?.icon)
+    }
+
     private suspend fun GoogleReaderRssService.fetchItemIdsAndContinueForTest(
         getItemIdsFunc: suspend (String?) -> GoogleReaderDTO.ItemIds?,
     ): MutableList<String> {
@@ -82,5 +144,46 @@ class GoogleReaderRssServiceTest {
 
     private fun newUninitializedService(): GoogleReaderRssService {
         return ObjenesisStd().newInstance(GoogleReaderRssService::class.java)
+    }
+
+    private fun testFeed(
+        id: String,
+        url: String = "https://example.com/feed",
+        icon: String? = null,
+        groupId: String = "1\$Defaults",
+        accountId: Int = 1,
+    ) = Feed(
+        id = id,
+        name = "E2E Feed",
+        icon = icon,
+        url = url,
+        groupId = groupId,
+        accountId = accountId,
+    )
+
+    private class RecordingSubscriptionStore(
+        private val existingIds: Set<String> = emptySet(),
+    ) : SubscriptionStore {
+        val savedGroups = mutableListOf<Group>()
+        val savedFeedsById = linkedMapOf<String, Feed>()
+        var updatedBeforeInsert = false
+            private set
+
+        override suspend fun existingFeedIds(): Set<String> = existingIds
+
+        override suspend fun insertOrUpdate(groups: List<Group>, feeds: List<Feed>) {
+            savedGroups += groups
+            feeds.forEach { savedFeedsById[it.id] = it }
+        }
+
+        override suspend fun updateFeeds(feeds: List<Feed>) {
+            feeds.forEach {
+                if (savedFeedsById.containsKey(it.id)) {
+                    savedFeedsById[it.id] = it
+                } else {
+                    updatedBeforeInsert = true
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
## Summary
- extract a subscription persistence seam around the Google Reader sync path
- add a regression test for favicon backfill ordering
- persist feeds before applying favicon backfill updates

fix #8