### PR TITLE
[codex] Fix issue #12 deprecation cleanup

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,6 +1,7 @@
 import java.io.FileInputStream
 import java.util.Properties
 import org.jetbrains.kotlin.compose.compiler.gradle.ComposeFeatureFlag
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 
 plugins {
     alias(libs.plugins.kotlin.android)
@@ -104,10 +105,6 @@ android {
                 "ReadYou-${defaultConfig.versionName}-${gitCommitHash}.apk"
         }
     }
-    kotlinOptions {
-        freeCompilerArgs = freeCompilerArgs + "-opt-in=kotlin.RequiresOptIn"
-        jvmTarget = JavaVersion.VERSION_11.toString()
-    }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_11
         targetCompatibility = JavaVersion.VERSION_11
@@ -120,6 +117,13 @@ android {
     androidResources { generateLocaleConfig = true }
     composeCompiler { featureFlags = setOf(ComposeFeatureFlag.PausableComposition) }
     namespace = "me.ash.reader"
+}
+
+kotlin {
+    compilerOptions {
+        optIn.add("kotlin.RequiresOptIn")
+        jvmTarget.set(JvmTarget.JVM_11)
+    }
 }
 
 aboutLibraries { excludeFields = arrayOf("generated") }

--- a/app/src/main/java/me/ash/reader/domain/service/AccountService.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/AccountService.kt
@@ -25,7 +25,7 @@ import me.ash.reader.domain.repository.FeedDao
 import me.ash.reader.domain.repository.GroupDao
 import me.ash.reader.infrastructure.di.ApplicationScope
 import me.ash.reader.infrastructure.preference.SettingsProvider
-import me.ash.reader.ui.ext.DataStoreKey
+import me.ash.reader.ui.ext.PreferencesKey
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.getDefaultGroupId
 import me.ash.reader.ui.ext.put
@@ -44,7 +44,7 @@ constructor(
     settingsProvider: SettingsProvider,
 ) {
 
-    private val accountIdKey = intPreferencesKey(DataStoreKey.currentAccountId)
+    private val accountIdKey = intPreferencesKey(PreferencesKey.currentAccountId)
 
     val currentAccountIdFlow =
         settingsProvider.preferencesFlow
@@ -88,8 +88,8 @@ constructor(
                     )
                 }
             }
-            context.dataStore.put(DataStoreKey.currentAccountId, it.id!!)
-            context.dataStore.put(DataStoreKey.currentAccountType, it.type.id)
+            context.dataStore.put(PreferencesKey.currentAccountId, it.id!!)
+            context.dataStore.put(PreferencesKey.currentAccountType, it.type.id)
         }
     }
 
@@ -143,14 +143,14 @@ constructor(
             groupDao.deleteByAccountId(accountId)
             accountDao.delete(it)
             accountDao.queryAll().getOrNull(0)?.let {
-                context.dataStore.put(DataStoreKey.currentAccountId, it.id!!)
-                context.dataStore.put(DataStoreKey.currentAccountType, it.type.id)
+                context.dataStore.put(PreferencesKey.currentAccountId, it.id!!)
+                context.dataStore.put(PreferencesKey.currentAccountType, it.type.id)
             }
         }
     }
 
     suspend fun switch(account: Account) {
-        context.dataStore.put(DataStoreKey.currentAccountId, account.id!!)
-        context.dataStore.put(DataStoreKey.currentAccountType, account.type.id)
+        context.dataStore.put(PreferencesKey.currentAccountId, account.id!!)
+        context.dataStore.put(PreferencesKey.currentAccountType, account.type.id)
     }
 }

--- a/app/src/main/java/me/ash/reader/infrastructure/android/CrashReportActivity.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/android/CrashReportActivity.kt
@@ -1,5 +1,6 @@
 package me.ash.reader.infrastructure.android
 
+import android.content.ClipData
 import android.os.Build
 import android.os.Bundle
 import androidx.activity.compose.setContent
@@ -16,7 +17,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.text.ClickableText
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.BugReport
@@ -29,30 +29,25 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.platform.LocalClipboardManager
-import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalClipboard
+import androidx.compose.ui.platform.toClipEntry
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.AnnotatedString
 import androidx.compose.ui.text.ExperimentalTextApi
 import androidx.compose.ui.text.LinkAnnotation
-import androidx.compose.ui.text.SpanStyle
-import androidx.compose.ui.text.UrlAnnotation
 import androidx.compose.ui.text.buildAnnotatedString
 import androidx.compose.ui.text.font.FontFamily
-import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import dagger.hilt.android.AndroidEntryPoint
 import me.ash.reader.R
 import me.ash.reader.infrastructure.preference.LocalDarkTheme
-import me.ash.reader.infrastructure.preference.LocalOpenLink
-import me.ash.reader.infrastructure.preference.LocalOpenLinkSpecificBrowser
 import me.ash.reader.infrastructure.preference.SettingsProvider
 import me.ash.reader.ui.ext.getCurrentVersion
-import me.ash.reader.ui.ext.openURL
 import me.ash.reader.ui.theme.AppTheme
 import javax.inject.Inject
+import kotlinx.coroutines.launch
 
 @AndroidEntryPoint
 class CrashReportActivity : AppCompatActivity() {
@@ -69,7 +64,8 @@ class CrashReportActivity : AppCompatActivity() {
         setContent {
             settingsProvider.ProvidesSettings {
                 AppTheme(useDarkTheme = LocalDarkTheme.current.isDarkTheme()) {
-                    val clipboardManager = LocalClipboardManager.current
+                    val clipboard = LocalClipboard.current
+                    val coroutineScope = rememberCoroutineScope()
                     val appVersion = getCurrentVersion().toString()
                     val deviceModel = "${Build.MANUFACTURER} ${Build.MODEL}"
                     val androidVersion =
@@ -83,7 +79,14 @@ class CrashReportActivity : AppCompatActivity() {
                     val stacktraceBlock = "Stack trace: \n\n```$errorMessage```"
 
                     CrashReportPage(text = prefix + stackTrace) {
-                        clipboardManager.setText(AnnotatedString(prefix + stacktraceBlock))
+                        coroutineScope.launch {
+                            clipboard.setClipEntry(
+                                ClipData.newPlainText(
+                                    "ReadYou crash report",
+                                    prefix + stacktraceBlock,
+                                ).toClipEntry()
+                            )
+                        }
                     }
                 }
             }

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/AmoledDarkThemePreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/AmoledDarkThemePreference.kt
@@ -5,8 +5,8 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.amoledDarkTheme
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.amoledDarkTheme
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -19,7 +19,7 @@ sealed class AmoledDarkThemePreference(val value: Boolean) : Preference() {
 
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
-            context.dataStore.put(DataStoreKey.amoledDarkTheme, value)
+            context.dataStore.put(PreferencesKey.amoledDarkTheme, value)
         }
     }
 
@@ -29,7 +29,7 @@ sealed class AmoledDarkThemePreference(val value: Boolean) : Preference() {
         val values = listOf(ON, OFF)
 
         fun fromPreferences(preferences: Preferences) =
-            when (preferences[DataStoreKey.keys[amoledDarkTheme]?.key as Preferences.Key<Boolean>]) {
+            when (preferences[PreferencesKey.keys[amoledDarkTheme]?.key as Preferences.Key<Boolean>]) {
                 true -> ON
                 false -> OFF
                 else -> default

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/BasicFontsPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/BasicFontsPreference.kt
@@ -8,8 +8,8 @@ import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import me.ash.reader.R
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.basicFonts
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.basicFonts
 import me.ash.reader.ui.ext.ExternalFonts
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
@@ -29,7 +29,7 @@ sealed class BasicFontsPreference(val value: Int) : Preference() {
 
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
-            context.dataStore.put(DataStoreKey.basicFonts, value)
+            context.dataStore.put(PreferencesKey.basicFonts, value)
             if (this@BasicFontsPreference == External) {
                 context.restart()
             }
@@ -65,7 +65,7 @@ sealed class BasicFontsPreference(val value: Int) : Preference() {
         val values = listOf(GoogleSans, System, External)
 
         fun fromPreferences(preferences: Preferences): BasicFontsPreference =
-            when (preferences[DataStoreKey.keys[basicFonts]?.key as Preferences.Key<Int>]) {
+            when (preferences[PreferencesKey.keys[basicFonts]?.key as Preferences.Key<Int>]) {
                 0 -> System
                 1 -> GoogleSans
                 5 -> External

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/CustomPrimaryColorPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/CustomPrimaryColorPreference.kt
@@ -5,8 +5,8 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.customPrimaryColor
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.customPrimaryColor
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -19,10 +19,10 @@ object CustomPrimaryColorPreference {
 
     fun put(context: Context, scope: CoroutineScope, value: String) {
         scope.launch {
-            context.dataStore.put(DataStoreKey.customPrimaryColor, value)
+            context.dataStore.put(PreferencesKey.customPrimaryColor, value)
         }
     }
 
     fun fromPreferences(preferences: Preferences) =
-        preferences[DataStoreKey.keys[customPrimaryColor]?.key as Preferences.Key<String>] ?: default
+        preferences[PreferencesKey.keys[customPrimaryColor]?.key as Preferences.Key<String>] ?: default
 }

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/DarkThemePreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/DarkThemePreference.kt
@@ -9,8 +9,8 @@ import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import me.ash.reader.R
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.darkTheme
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.darkTheme
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -49,7 +49,7 @@ sealed class DarkThemePreference(val value: Int) : Preference() {
         val values = listOf(UseDeviceTheme, ON, OFF)
 
         fun fromPreferences(preferences: Preferences) =
-            when (preferences[DataStoreKey.keys[darkTheme]?.key as Preferences.Key<Int>]) {
+            when (preferences[PreferencesKey.keys[darkTheme]?.key as Preferences.Key<Int>]) {
                 0 -> UseDeviceTheme
                 1 -> ON
                 2 -> OFF

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/FeedsFilterBarPaddingPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/FeedsFilterBarPaddingPreference.kt
@@ -5,8 +5,8 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.feedsFilterBarPadding
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.feedsFilterBarPadding
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -19,10 +19,10 @@ object FeedsFilterBarPaddingPreference {
 
     fun put(context: Context, scope: CoroutineScope, value: Int) {
         scope.launch {
-            context.dataStore.put(DataStoreKey.feedsFilterBarPadding, value)
+            context.dataStore.put(PreferencesKey.feedsFilterBarPadding, value)
         }
     }
 
     fun fromPreferences(preferences: Preferences) =
-        preferences[DataStoreKey.keys[feedsFilterBarPadding]?.key as Preferences.Key<Int>] ?: default
+        preferences[PreferencesKey.keys[feedsFilterBarPadding]?.key as Preferences.Key<Int>] ?: default
 }

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/FeedsFilterBarStylePreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/FeedsFilterBarStylePreference.kt
@@ -6,8 +6,8 @@ import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import me.ash.reader.R
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.feedsFilterBarStyle
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.feedsFilterBarStyle
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -22,7 +22,7 @@ sealed class FeedsFilterBarStylePreference(val value: Int) : Preference() {
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
             context.dataStore.put(
-                DataStoreKey.feedsFilterBarStyle,
+                PreferencesKey.feedsFilterBarStyle,
                 value
             )
         }
@@ -41,7 +41,7 @@ sealed class FeedsFilterBarStylePreference(val value: Int) : Preference() {
         val values = listOf(Icon, IconLabel, IconLabelOnlySelected)
 
         fun fromPreferences(preferences: Preferences): FeedsFilterBarStylePreference =
-            when (preferences[DataStoreKey.keys[feedsFilterBarStyle]?.key as Preferences.Key<Int>]) {
+            when (preferences[PreferencesKey.keys[feedsFilterBarStyle]?.key as Preferences.Key<Int>]) {
                 0 -> Icon
                 1 -> IconLabel
                 2 -> IconLabelOnlySelected

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/FeedsFilterBarTonalElevationPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/FeedsFilterBarTonalElevationPreference.kt
@@ -6,8 +6,8 @@ import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import me.ash.reader.domain.model.constant.ElevationTokens
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.feedsFilterBarTonalElevation
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.feedsFilterBarTonalElevation
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -25,7 +25,7 @@ sealed class FeedsFilterBarTonalElevationPreference(val value: Int) : Preference
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
             context.dataStore.put(
-                DataStoreKey.feedsFilterBarTonalElevation,
+                PreferencesKey.feedsFilterBarTonalElevation,
                 value
             )
         }
@@ -47,7 +47,7 @@ sealed class FeedsFilterBarTonalElevationPreference(val value: Int) : Preference
         val values = listOf(Level0, Level1, Level2, Level3, Level4, Level5)
 
         fun fromPreferences(preferences: Preferences) =
-            when (preferences[DataStoreKey.keys[feedsFilterBarTonalElevation]?.key as Preferences.Key<Int>]) {
+            when (preferences[PreferencesKey.keys[feedsFilterBarTonalElevation]?.key as Preferences.Key<Int>]) {
                 ElevationTokens.Level0 -> Level0
                 ElevationTokens.Level1 -> Level1
                 ElevationTokens.Level2 -> Level2

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/FeedsGroupListExpandPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/FeedsGroupListExpandPreference.kt
@@ -5,8 +5,8 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.feedsGroupListExpand
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.feedsGroupListExpand
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -20,7 +20,7 @@ sealed class FeedsGroupListExpandPreference(val value: Boolean) : Preference() {
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
             context.dataStore.put(
-                DataStoreKey.feedsGroupListExpand,
+                PreferencesKey.feedsGroupListExpand,
                 value
             )
         }
@@ -32,7 +32,7 @@ sealed class FeedsGroupListExpandPreference(val value: Boolean) : Preference() {
         val values = listOf(ON, OFF)
 
         fun fromPreferences(preferences: Preferences) =
-            when (preferences[DataStoreKey.keys[feedsGroupListExpand]?.key as Preferences.Key<Boolean>]) {
+            when (preferences[PreferencesKey.keys[feedsGroupListExpand]?.key as Preferences.Key<Boolean>]) {
                 true -> ON
                 false -> OFF
                 else -> default

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/FeedsGroupListTonalElevationPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/FeedsGroupListTonalElevationPreference.kt
@@ -6,8 +6,8 @@ import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import me.ash.reader.domain.model.constant.ElevationTokens
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.feedsGroupListTonalElevation
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.feedsGroupListTonalElevation
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -25,7 +25,7 @@ sealed class FeedsGroupListTonalElevationPreference(val value: Int) : Preference
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
             context.dataStore.put(
-                DataStoreKey.feedsGroupListTonalElevation,
+                PreferencesKey.feedsGroupListTonalElevation,
                 value
             )
         }
@@ -47,7 +47,7 @@ sealed class FeedsGroupListTonalElevationPreference(val value: Int) : Preference
         val values = listOf(Level0, Level1, Level2, Level3, Level4, Level5)
 
         fun fromPreferences(preferences: Preferences) =
-            when (preferences[DataStoreKey.keys[feedsGroupListTonalElevation]?.key as Preferences.Key<Int>]) {
+            when (preferences[PreferencesKey.keys[feedsGroupListTonalElevation]?.key as Preferences.Key<Int>]) {
                 ElevationTokens.Level0 -> Level0
                 ElevationTokens.Level1 -> Level1
                 ElevationTokens.Level2 -> Level2

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/FeedsTopBarTonalElevationPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/FeedsTopBarTonalElevationPreference.kt
@@ -6,8 +6,8 @@ import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import me.ash.reader.domain.model.constant.ElevationTokens
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.feedsTopBarTonalElevation
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.feedsTopBarTonalElevation
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -25,7 +25,7 @@ sealed class FeedsTopBarTonalElevationPreference(val value: Int) : Preference() 
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
             context.dataStore.put(
-                DataStoreKey.feedsTopBarTonalElevation,
+                PreferencesKey.feedsTopBarTonalElevation,
                 value
             )
         }
@@ -47,7 +47,7 @@ sealed class FeedsTopBarTonalElevationPreference(val value: Int) : Preference() 
         val values = listOf(Level0, Level1, Level2, Level3, Level4, Level5)
 
         fun fromPreferences(preferences: Preferences) =
-            when (preferences[DataStoreKey.keys[feedsTopBarTonalElevation]?.key as Preferences.Key<Int>]) {
+            when (preferences[PreferencesKey.keys[feedsTopBarTonalElevation]?.key as Preferences.Key<Int>]) {
                 ElevationTokens.Level0 -> Level0
                 ElevationTokens.Level1 -> Level1
                 ElevationTokens.Level2 -> Level2

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/FlowArticleListDateStickyHeaderPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/FlowArticleListDateStickyHeaderPreference.kt
@@ -5,8 +5,8 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.flowArticleListDateStickyHeader
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.flowArticleListDateStickyHeader
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -20,7 +20,7 @@ sealed class FlowArticleListDateStickyHeaderPreference(val value: Boolean) : Pre
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
             context.dataStore.put(
-                DataStoreKey.flowArticleListDateStickyHeader,
+                PreferencesKey.flowArticleListDateStickyHeader,
                 value
             )
         }
@@ -32,7 +32,7 @@ sealed class FlowArticleListDateStickyHeaderPreference(val value: Boolean) : Pre
         val values = listOf(ON, OFF)
 
         fun fromPreferences(preferences: Preferences) =
-            when (preferences[DataStoreKey.keys[flowArticleListDateStickyHeader]?.key as Preferences.Key<Boolean>]) {
+            when (preferences[PreferencesKey.keys[flowArticleListDateStickyHeader]?.key as Preferences.Key<Boolean>]) {
                 true -> ON
                 false -> OFF
                 else -> default

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/FlowArticleListDescPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/FlowArticleListDescPreference.kt
@@ -8,8 +8,8 @@ import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import me.ash.reader.R
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.flowArticleListDesc
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.flowArticleListDesc
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -24,7 +24,7 @@ sealed class FlowArticleListDescPreference(val value: Int) : Preference() {
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
             context.dataStore.put(
-                DataStoreKey.flowArticleListDesc,
+                PreferencesKey.flowArticleListDesc,
                 value
             )
         }
@@ -45,7 +45,7 @@ sealed class FlowArticleListDescPreference(val value: Int) : Preference() {
         val values = listOf(NONE, SHORT, LONG)
 
         fun fromPreferences(preferences: Preferences) =
-            when (preferences[DataStoreKey.keys[flowArticleListDesc]?.key as Preferences.Key<*>]) {
+            when (preferences[PreferencesKey.keys[flowArticleListDesc]?.key as Preferences.Key<*>]) {
                 0 -> NONE
                 1 -> SHORT
                 2 -> LONG

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/FlowArticleListFeedIconPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/FlowArticleListFeedIconPreference.kt
@@ -5,8 +5,8 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.flowArticleListFeedIcon
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.flowArticleListFeedIcon
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -20,7 +20,7 @@ sealed class FlowArticleListFeedIconPreference(val value: Boolean) : Preference(
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
             context.dataStore.put(
-                DataStoreKey.flowArticleListFeedIcon,
+                PreferencesKey.flowArticleListFeedIcon,
                 value
             )
         }
@@ -32,7 +32,7 @@ sealed class FlowArticleListFeedIconPreference(val value: Boolean) : Preference(
         val values = listOf(ON, OFF)
 
         fun fromPreferences(preferences: Preferences) =
-            when (preferences[DataStoreKey.keys[flowArticleListFeedIcon]?.key as Preferences.Key<Boolean>]) {
+            when (preferences[PreferencesKey.keys[flowArticleListFeedIcon]?.key as Preferences.Key<Boolean>]) {
                 true -> ON
                 false -> OFF
                 else -> default

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/FlowArticleListFeedNamePreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/FlowArticleListFeedNamePreference.kt
@@ -5,8 +5,8 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.flowArticleListFeedName
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.flowArticleListFeedName
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -20,7 +20,7 @@ sealed class FlowArticleListFeedNamePreference(val value: Boolean) : Preference(
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
             context.dataStore.put(
-                DataStoreKey.flowArticleListFeedName,
+                PreferencesKey.flowArticleListFeedName,
                 value
             )
         }
@@ -32,7 +32,7 @@ sealed class FlowArticleListFeedNamePreference(val value: Boolean) : Preference(
         val values = listOf(ON, OFF)
 
         fun fromPreferences(preferences: Preferences) =
-            when (preferences[DataStoreKey.keys[flowArticleListFeedName]?.key as Preferences.Key<Boolean>]) {
+            when (preferences[PreferencesKey.keys[flowArticleListFeedName]?.key as Preferences.Key<Boolean>]) {
                 true -> ON
                 false -> OFF
                 else -> default

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/FlowArticleListImagePreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/FlowArticleListImagePreference.kt
@@ -5,8 +5,8 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.flowArticleListImage
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.flowArticleListImage
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -20,7 +20,7 @@ sealed class FlowArticleListImagePreference(val value: Boolean) : Preference() {
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
             context.dataStore.put(
-                DataStoreKey.flowArticleListImage,
+                PreferencesKey.flowArticleListImage,
                 value
             )
         }
@@ -32,7 +32,7 @@ sealed class FlowArticleListImagePreference(val value: Boolean) : Preference() {
         val values = listOf(ON, OFF)
 
         fun fromPreferences(preferences: Preferences) =
-            when (preferences[DataStoreKey.keys[flowArticleListImage]?.key as Preferences.Key<Boolean>]) {
+            when (preferences[PreferencesKey.keys[flowArticleListImage]?.key as Preferences.Key<Boolean>]) {
                 true -> ON
                 false -> OFF
                 else -> default

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/FlowArticleListTimePreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/FlowArticleListTimePreference.kt
@@ -5,8 +5,8 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.flowArticleListTime
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.flowArticleListTime
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -20,7 +20,7 @@ sealed class FlowArticleListTimePreference(val value: Boolean) : Preference() {
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
             context.dataStore.put(
-                DataStoreKey.flowArticleListTime,
+                PreferencesKey.flowArticleListTime,
                 value
             )
         }
@@ -32,7 +32,7 @@ sealed class FlowArticleListTimePreference(val value: Boolean) : Preference() {
         val values = listOf(ON, OFF)
 
         fun fromPreferences(preferences: Preferences) =
-            when (preferences[DataStoreKey.keys[flowArticleListTime]?.key as Preferences.Key<Boolean>]) {
+            when (preferences[PreferencesKey.keys[flowArticleListTime]?.key as Preferences.Key<Boolean>]) {
                 true -> ON
                 false -> OFF
                 else -> default

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/FlowArticleListTonalElevationPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/FlowArticleListTonalElevationPreference.kt
@@ -6,8 +6,8 @@ import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import me.ash.reader.domain.model.constant.ElevationTokens
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.flowArticleListTonalElevation
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.flowArticleListTonalElevation
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -25,7 +25,7 @@ sealed class FlowArticleListTonalElevationPreference(val value: Int) : Preferenc
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
             context.dataStore.put(
-                DataStoreKey.flowArticleListTonalElevation,
+                PreferencesKey.flowArticleListTonalElevation,
                 value
             )
         }
@@ -47,7 +47,7 @@ sealed class FlowArticleListTonalElevationPreference(val value: Int) : Preferenc
         val values = listOf(Level0, Level1, Level2, Level3, Level4, Level5)
 
         fun fromPreferences(preferences: Preferences) =
-            when (preferences[DataStoreKey.keys[flowArticleListTonalElevation]?.key as Preferences.Key<Int>]) {
+            when (preferences[PreferencesKey.keys[flowArticleListTonalElevation]?.key as Preferences.Key<Int>]) {
                 ElevationTokens.Level0 -> Level0
                 ElevationTokens.Level1 -> Level1
                 ElevationTokens.Level2 -> Level2

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/FlowArticleReadIndicatorPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/FlowArticleReadIndicatorPreference.kt
@@ -8,8 +8,8 @@ import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import me.ash.reader.R
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.flowArticleListReadIndicator
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.flowArticleListReadIndicator
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -45,7 +45,7 @@ sealed class FlowArticleReadIndicatorPreference(val value: Int) : Preference() {
         val values = listOf(ExcludingStarred, AllRead, None)
 
         fun fromPreferences(preferences: Preferences) =
-            when (preferences[DataStoreKey.keys[flowArticleListReadIndicator]?.key as Preferences.Key<Int>]) {
+            when (preferences[PreferencesKey.keys[flowArticleListReadIndicator]?.key as Preferences.Key<Int>]) {
                 0 -> ExcludingStarred
                 1 -> AllRead
                 2 -> None

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/FlowFilterBarPaddingPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/FlowFilterBarPaddingPreference.kt
@@ -5,8 +5,8 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.flowFilterBarPadding
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.flowFilterBarPadding
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -19,10 +19,10 @@ object FlowFilterBarPaddingPreference {
 
     fun put(context: Context, scope: CoroutineScope, value: Int) {
         scope.launch {
-            context.dataStore.put(DataStoreKey.flowFilterBarPadding, value)
+            context.dataStore.put(PreferencesKey.flowFilterBarPadding, value)
         }
     }
 
     fun fromPreferences(preferences: Preferences) =
-        preferences[DataStoreKey.keys[flowFilterBarPadding]?.key as Preferences.Key<Int>] ?: default
+        preferences[PreferencesKey.keys[flowFilterBarPadding]?.key as Preferences.Key<Int>] ?: default
 }

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/FlowFilterBarStylePreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/FlowFilterBarStylePreference.kt
@@ -6,8 +6,8 @@ import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import me.ash.reader.R
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.flowFilterBarStyle
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.flowFilterBarStyle
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -22,7 +22,7 @@ sealed class FlowFilterBarStylePreference(val value: Int) : Preference() {
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
             context.dataStore.put(
-                DataStoreKey.flowFilterBarStyle,
+                PreferencesKey.flowFilterBarStyle,
                 value
             )
         }
@@ -41,7 +41,7 @@ sealed class FlowFilterBarStylePreference(val value: Int) : Preference() {
         val values = listOf(Icon, IconLabel, IconLabelOnlySelected)
 
         fun fromPreferences(preferences: Preferences) =
-            when (preferences[DataStoreKey.keys[flowFilterBarStyle]?.key as Preferences.Key<Int>]) {
+            when (preferences[PreferencesKey.keys[flowFilterBarStyle]?.key as Preferences.Key<Int>]) {
                 0 -> Icon
                 1 -> IconLabel
                 2 -> IconLabelOnlySelected

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/FlowFilterBarTonalElevationPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/FlowFilterBarTonalElevationPreference.kt
@@ -6,8 +6,8 @@ import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import me.ash.reader.domain.model.constant.ElevationTokens
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.flowFilterBarTonalElevation
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.flowFilterBarTonalElevation
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -25,7 +25,7 @@ sealed class FlowFilterBarTonalElevationPreference(val value: Int) : Preference(
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
             context.dataStore.put(
-                DataStoreKey.flowFilterBarTonalElevation,
+                PreferencesKey.flowFilterBarTonalElevation,
                 value
             )
         }
@@ -47,7 +47,7 @@ sealed class FlowFilterBarTonalElevationPreference(val value: Int) : Preference(
         val values = listOf(Level0, Level1, Level2, Level3, Level4, Level5)
 
         fun fromPreferences(preferences: Preferences) =
-            when (preferences[DataStoreKey.keys[flowFilterBarTonalElevation]?.key as Preferences.Key<Int>]) {
+            when (preferences[PreferencesKey.keys[flowFilterBarTonalElevation]?.key as Preferences.Key<Int>]) {
                 ElevationTokens.Level0 -> Level0
                 ElevationTokens.Level1 -> Level1
                 ElevationTokens.Level2 -> Level2

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/FlowTopBarTonalElevationPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/FlowTopBarTonalElevationPreference.kt
@@ -6,8 +6,8 @@ import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import me.ash.reader.domain.model.constant.ElevationTokens
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.flowTopBarTonalElevation
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.flowTopBarTonalElevation
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -36,7 +36,7 @@ sealed class FlowTopBarTonalElevationPreference(val value: Int) : Preference() {
         val values = listOf(None, Elevated)
 
         fun fromPreferences(preferences: Preferences) =
-            when (preferences[DataStoreKey.keys[flowTopBarTonalElevation]?.key as Preferences.Key<Int>]) {
+            when (preferences[PreferencesKey.keys[flowTopBarTonalElevation]?.key as Preferences.Key<Int>]) {
                 ElevationTokens.Level0 -> None
                 ElevationTokens.Level2 -> Elevated
                 else -> default

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/HideEmptyGroupsPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/HideEmptyGroupsPreference.kt
@@ -5,8 +5,8 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.hideEmptyGroups
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.hideEmptyGroups
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -39,7 +39,7 @@ sealed class HideEmptyGroupsPreference(val value: Boolean) : Preference() {
         val values = listOf(ON, OFF)
 
         fun fromPreferences(preferences: Preferences) =
-            when (preferences[DataStoreKey.keys[hideEmptyGroups]?.key as Preferences.Key<Boolean>]) {
+            when (preferences[PreferencesKey.keys[hideEmptyGroups]?.key as Preferences.Key<Boolean>]) {
                 true -> ON
                 false -> OFF
                 else -> default

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/InitialFilterPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/InitialFilterPreference.kt
@@ -7,8 +7,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import me.ash.reader.R
 import me.ash.reader.domain.model.general.Filter
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.initialFilter
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.initialFilter
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -23,7 +23,7 @@ sealed class InitialFilterPreference(val value: Int) : Preference() {
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
             context.dataStore.put(
-                DataStoreKey.initialFilter,
+                PreferencesKey.initialFilter,
                 value
             )
         }
@@ -50,7 +50,7 @@ sealed class InitialFilterPreference(val value: Int) : Preference() {
         val values = listOf(Starred, Unread, All)
 
         fun fromPreferences(preferences: Preferences) =
-            when (preferences[DataStoreKey.keys[initialFilter]?.key as Preferences.Key<Int>]) {
+            when (preferences[PreferencesKey.keys[initialFilter]?.key as Preferences.Key<Int>]) {
                 0 -> Starred
                 1 -> Unread
                 2 -> All

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/InitialPagePreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/InitialPagePreference.kt
@@ -6,8 +6,8 @@ import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import me.ash.reader.R
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.initialPage
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.initialPage
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -20,7 +20,7 @@ sealed class InitialPagePreference(val value: Int) : Preference() {
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
             context.dataStore.put(
-                DataStoreKey.initialPage,
+                PreferencesKey.initialPage,
                 value
             )
         }
@@ -38,7 +38,7 @@ sealed class InitialPagePreference(val value: Int) : Preference() {
         val values = listOf(FeedsPage, FlowPage)
 
         fun fromPreferences(preferences: Preferences) =
-            when (preferences[DataStoreKey.keys[initialPage]?.key as Preferences.Key<Int>]) {
+            when (preferences[PreferencesKey.keys[initialPage]?.key as Preferences.Key<Int>]) {
                 0 -> FeedsPage
                 1 -> FlowPage
                 else -> default

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/LanguagesPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/LanguagesPreference.kt
@@ -11,8 +11,8 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import me.ash.reader.R
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.languages
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.languages
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 import java.util.Locale
@@ -66,7 +66,7 @@ sealed class LanguagesPreference(val value: Int) : Preference() {
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
             context.dataStore.put(
-                DataStoreKey.languages, value
+                PreferencesKey.languages, value
             )
             scope.launch(Dispatchers.Main) { setLocale(this@LanguagesPreference) }
         }
@@ -180,7 +180,7 @@ sealed class LanguagesPreference(val value: Int) : Preference() {
         )
 
         fun fromPreferences(preferences: Preferences): LanguagesPreference =
-            fromValue(preferences[DataStoreKey.keys[languages]?.key as Preferences.Key<Int>] ?: 0)
+            fromValue(preferences[PreferencesKey.keys[languages]?.key as Preferences.Key<Int>] ?: 0)
 
 
         fun fromValue(value: Int): LanguagesPreference = when (value) {

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/MarkAsReadOnScrollPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/MarkAsReadOnScrollPreference.kt
@@ -5,8 +5,8 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.markAsReadOnScroll
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.markAsReadOnScroll
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -39,7 +39,7 @@ sealed class MarkAsReadOnScrollPreference(val value: Boolean) : Preference() {
         val values = listOf(ON, OFF)
 
         fun fromPreferences(preferences: Preferences) =
-            when (preferences[DataStoreKey.keys[markAsReadOnScroll]?.key as Preferences.Key<Boolean>]) {
+            when (preferences[PreferencesKey.keys[markAsReadOnScroll]?.key as Preferences.Key<Boolean>]) {
                 true -> ON
                 false -> OFF
                 else -> default

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/NewVersionDownloadUrlPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/NewVersionDownloadUrlPreference.kt
@@ -6,8 +6,8 @@ import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.newVersionDownloadUrl
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.newVersionDownloadUrl
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -19,10 +19,10 @@ object NewVersionDownloadUrlPreference {
 
     fun put(context: Context, scope: CoroutineScope, value: String) {
         scope.launch(Dispatchers.IO) {
-            context.dataStore.put(DataStoreKey.newVersionDownloadUrl, value)
+            context.dataStore.put(PreferencesKey.newVersionDownloadUrl, value)
         }
     }
 
     fun fromPreferences(preferences: Preferences) =
-        preferences[DataStoreKey.keys[newVersionDownloadUrl]?.key as Preferences.Key<String>] ?: default
+        preferences[PreferencesKey.keys[newVersionDownloadUrl]?.key as Preferences.Key<String>] ?: default
 }

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/NewVersionLogPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/NewVersionLogPreference.kt
@@ -6,8 +6,8 @@ import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.newVersionLog
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.newVersionLog
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -19,10 +19,10 @@ object NewVersionLogPreference {
 
     fun put(context: Context, scope: CoroutineScope, value: String) {
         scope.launch(Dispatchers.IO) {
-            context.dataStore.put(DataStoreKey.newVersionLog, value)
+            context.dataStore.put(PreferencesKey.newVersionLog, value)
         }
     }
 
     fun fromPreferences(preferences: Preferences) =
-        preferences[DataStoreKey.keys[newVersionLog]?.key as Preferences.Key<String>] ?: default
+        preferences[PreferencesKey.keys[newVersionLog]?.key as Preferences.Key<String>] ?: default
 }

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/NewVersionNumberPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/NewVersionNumberPreference.kt
@@ -9,8 +9,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import me.ash.reader.domain.model.general.Version
 import me.ash.reader.domain.model.general.toVersion
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.newVersionNumber
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.newVersionNumber
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -30,5 +30,5 @@ object NewVersionNumberPreference {
     }
 
     fun fromPreferences(preferences: Preferences) =
-        preferences[DataStoreKey.keys[newVersionNumber]?.key as Preferences.Key<String>].toVersion()
+        preferences[PreferencesKey.keys[newVersionNumber]?.key as Preferences.Key<String>].toVersion()
 }

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/NewVersionPublishDatePreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/NewVersionPublishDatePreference.kt
@@ -6,8 +6,8 @@ import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.newVersionPublishDate
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.newVersionPublishDate
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -19,10 +19,10 @@ object NewVersionPublishDatePreference {
 
     fun put(context: Context, scope: CoroutineScope, value: String) {
         scope.launch(Dispatchers.IO) {
-            context.dataStore.put(DataStoreKey.newVersionPublishDate, value)
+            context.dataStore.put(PreferencesKey.newVersionPublishDate, value)
         }
     }
 
     fun fromPreferences(preferences: Preferences) =
-        preferences[DataStoreKey.keys[newVersionPublishDate]?.key as Preferences.Key<String>] ?: default
+        preferences[PreferencesKey.keys[newVersionPublishDate]?.key as Preferences.Key<String>] ?: default
 }

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/NewVersionSizePreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/NewVersionSizePreference.kt
@@ -6,8 +6,8 @@ import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.newVersionSizeString
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.newVersionSizeString
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -29,5 +29,5 @@ object NewVersionSizePreference {
     }
 
     fun fromPreferences(preferences: Preferences) =
-        preferences[DataStoreKey.keys[newVersionSizeString]?.key as Preferences.Key<String>] ?: default
+        preferences[PreferencesKey.keys[newVersionSizeString]?.key as Preferences.Key<String>] ?: default
 }

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/OpenLinkPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/OpenLinkPreference.kt
@@ -6,8 +6,8 @@ import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import me.ash.reader.R
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.openLink
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.openLink
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -26,7 +26,7 @@ sealed class OpenLinkPreference(val value: Int) : Preference() {
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
             context.dataStore.put(
-                DataStoreKey.openLink,
+                PreferencesKey.openLink,
                 value
             )
         }
@@ -48,7 +48,7 @@ sealed class OpenLinkPreference(val value: Int) : Preference() {
         val values = listOf(AutoPreferCustomTabs, AutoPreferDefaultBrowser, CustomTabs, DefaultBrowser, SpecificBrowser, AlwaysAsk)
 
         fun fromPreferences(preferences: Preferences) =
-            when (preferences[DataStoreKey.keys[openLink]?.key as Preferences.Key<Int>]) {
+            when (preferences[PreferencesKey.keys[openLink]?.key as Preferences.Key<Int>]) {
                 0 -> AutoPreferCustomTabs
                 1 -> AutoPreferDefaultBrowser
                 2 -> CustomTabs

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/OpenLinkSpecificBrowserPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/OpenLinkSpecificBrowserPreference.kt
@@ -8,8 +8,8 @@ import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import me.ash.reader.R
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.openLinkAppSpecificBrowser
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.openLinkAppSpecificBrowser
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -23,7 +23,7 @@ data class OpenLinkSpecificBrowserPreference(
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
             context.dataStore.put(
-                DataStoreKey.openLinkAppSpecificBrowser,
+                PreferencesKey.openLinkAppSpecificBrowser,
                 packageName.orEmpty()
             )
         }
@@ -52,7 +52,7 @@ data class OpenLinkSpecificBrowserPreference(
     companion object {
         val default = OpenLinkSpecificBrowserPreference(null)
         fun fromPreferences(preferences: Preferences): OpenLinkSpecificBrowserPreference {
-            val packageName = preferences[DataStoreKey.keys[openLinkAppSpecificBrowser]?.key as Preferences.Key<String>]
+            val packageName = preferences[PreferencesKey.keys[openLinkAppSpecificBrowser]?.key as Preferences.Key<String>]
             return OpenLinkSpecificBrowserPreference(packageName)
         }
     }

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/PullToLoadNextFeedPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/PullToLoadNextFeedPreference.kt
@@ -7,8 +7,8 @@ import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import me.ash.reader.R
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.pullToLoadNextFeed
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.pullToLoadNextFeed
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -46,7 +46,7 @@ sealed class PullToLoadNextFeedPreference(val value: Int) : Preference() {
 
         fun fromPreference(preference: Preferences): PullToLoadNextFeedPreference {
             val value =
-                preference[DataStoreKey.keys[pullToLoadNextFeed]?.key as Preferences.Key<Int>]
+                preference[PreferencesKey.keys[pullToLoadNextFeed]?.key as Preferences.Key<Int>]
             return when (value) {
                 0 -> None
                 1 -> LoadNextFeed

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/PullToSwitchArticlePreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/PullToSwitchArticlePreference.kt
@@ -5,8 +5,8 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.pullToSwitchArticle
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.pullToSwitchArticle
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -15,7 +15,7 @@ val LocalPullToSwitchArticle = compositionLocalOf { PullToSwitchArticlePreferenc
 class PullToSwitchArticlePreference(val value: Boolean) : Preference() {
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
-            context.dataStore.put(DataStoreKey.pullToSwitchArticle, value)
+            context.dataStore.put(PreferencesKey.pullToSwitchArticle, value)
         }
     }
 
@@ -26,7 +26,7 @@ class PullToSwitchArticlePreference(val value: Boolean) : Preference() {
         val default = PullToSwitchArticlePreference(true)
         fun fromPreference(preference: Preferences): PullToSwitchArticlePreference {
             return PullToSwitchArticlePreference(
-                preference[DataStoreKey.keys[pullToSwitchArticle]?.key as Preferences.Key<Boolean>] ?: return default
+                preference[PreferencesKey.keys[pullToSwitchArticle]?.key as Preferences.Key<Boolean>] ?: return default
             )
         }
     }

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingAutoHideToolbarPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingAutoHideToolbarPreference.kt
@@ -5,8 +5,8 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.readingAutoHideToolbar
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.readingAutoHideToolbar
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -19,7 +19,7 @@ sealed class ReadingAutoHideToolbarPreference(val value: Boolean) : Preference()
 
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
-            context.dataStore.put(DataStoreKey.readingAutoHideToolbar, value)
+            context.dataStore.put(PreferencesKey.readingAutoHideToolbar, value)
         }
     }
 
@@ -29,7 +29,7 @@ sealed class ReadingAutoHideToolbarPreference(val value: Boolean) : Preference()
         val values = listOf(ON, OFF)
 
         fun fromPreferences(preferences: Preferences) =
-            when (preferences[DataStoreKey.keys[readingAutoHideToolbar]?.key as Preferences.Key<Boolean>]) {
+            when (preferences[PreferencesKey.keys[readingAutoHideToolbar]?.key as Preferences.Key<Boolean>]) {
                 true -> ON
                 false -> OFF
                 else -> default

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingBoldCharactersPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingBoldCharactersPreference.kt
@@ -5,8 +5,8 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.readingBoldCharacters
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.readingBoldCharacters
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -29,7 +29,7 @@ sealed class ReadingBoldCharactersPreference(val value: Boolean) : Preference() 
         val values = listOf(ON, OFF)
 
         fun fromPreferences(preferences: Preferences) =
-            when (preferences[DataStoreKey.keys[readingBoldCharacters]?.key as Preferences.Key<Boolean>]) {
+            when (preferences[PreferencesKey.keys[readingBoldCharacters]?.key as Preferences.Key<Boolean>]) {
                 true -> ON
                 false -> OFF
                 else -> default

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingFontsPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingFontsPreference.kt
@@ -7,8 +7,8 @@ import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import me.ash.reader.R
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.readingFonts
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.readingFonts
 import me.ash.reader.ui.ext.ExternalFonts
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
@@ -35,7 +35,7 @@ sealed class ReadingFontsPreference(val value: Int) : Preference() {
 
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
-            context.dataStore.put(DataStoreKey.readingFonts, value)
+            context.dataStore.put(PreferencesKey.readingFonts, value)
             if (this@ReadingFontsPreference == External) {
                 context.restart()
             }
@@ -72,7 +72,7 @@ sealed class ReadingFontsPreference(val value: Int) : Preference() {
         val values = listOf(GoogleSans, System, Serif, SansSerif, Monospace, Cursive, External)
 
         fun fromPreferences(preferences: Preferences): ReadingFontsPreference =
-            when (preferences[DataStoreKey.keys[readingFonts]?.key as Preferences.Key<Int>]) {
+            when (preferences[PreferencesKey.keys[readingFonts]?.key as Preferences.Key<Int>]) {
                 0 -> System
                 1 -> Serif
                 2 -> SansSerif

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingImageHorizontalPaddingPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingImageHorizontalPaddingPreference.kt
@@ -5,8 +5,8 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.readingImageHorizontalPadding
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.readingImageHorizontalPadding
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -19,10 +19,10 @@ object ReadingImageHorizontalPaddingPreference {
 
     fun put(context: Context, scope: CoroutineScope, value: Int) {
         scope.launch {
-            context.dataStore.put(DataStoreKey.readingImageHorizontalPadding, value)
+            context.dataStore.put(PreferencesKey.readingImageHorizontalPadding, value)
         }
     }
 
     fun fromPreferences(preferences: Preferences) =
-        preferences[DataStoreKey.keys[readingImageHorizontalPadding]?.key as Preferences.Key<Int>] ?: default
+        preferences[PreferencesKey.keys[readingImageHorizontalPadding]?.key as Preferences.Key<Int>] ?: default
 }

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingImageMaximizePreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingImageMaximizePreference.kt
@@ -5,8 +5,8 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.readingImageMaximize
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.readingImageMaximize
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -19,7 +19,7 @@ sealed class ReadingImageMaximizePreference(val value: Boolean) : Preference() {
 
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
-            context.dataStore.put(DataStoreKey.readingImageMaximize, value)
+            context.dataStore.put(PreferencesKey.readingImageMaximize, value)
         }
     }
 
@@ -29,7 +29,7 @@ sealed class ReadingImageMaximizePreference(val value: Boolean) : Preference() {
         val values = listOf(ON, OFF)
 
         fun fromPreferences(preferences: Preferences) =
-            when (preferences[DataStoreKey.keys[readingImageMaximize]?.key as Preferences.Key<Boolean>]) {
+            when (preferences[PreferencesKey.keys[readingImageMaximize]?.key as Preferences.Key<Boolean>]) {
                 true -> ON
                 false -> OFF
                 else -> default

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingImageRoundedCornersPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingImageRoundedCornersPreference.kt
@@ -5,8 +5,8 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.readingImageRoundedCorners
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.readingImageRoundedCorners
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -19,10 +19,10 @@ object ReadingImageRoundedCornersPreference {
 
     fun put(context: Context, scope: CoroutineScope, value: Int) {
         scope.launch {
-            context.dataStore.put(DataStoreKey.readingImageRoundedCorners, value)
+            context.dataStore.put(PreferencesKey.readingImageRoundedCorners, value)
         }
     }
 
     fun fromPreferences(preferences: Preferences) =
-        preferences[DataStoreKey.keys[readingImageRoundedCorners]?.key as Preferences.Key<Int>] ?: default
+        preferences[PreferencesKey.keys[readingImageRoundedCorners]?.key as Preferences.Key<Int>] ?: default
 }

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingPageTonalElevationPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingPageTonalElevationPreference.kt
@@ -6,8 +6,8 @@ import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import me.ash.reader.domain.model.constant.ElevationTokens
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.readingPageTonalElevation
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.readingPageTonalElevation
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -36,7 +36,7 @@ sealed class ReadingPageTonalElevationPreference(val value: Int) : Preference() 
         val values = listOf(Outlined, Elevated)
 
         fun fromPreferences(preferences: Preferences) =
-            when (preferences[DataStoreKey.keys[readingPageTonalElevation]?.key as Preferences.Key<Int>]) {
+            when (preferences[PreferencesKey.keys[readingPageTonalElevation]?.key as Preferences.Key<Int>]) {
                 ElevationTokens.Level0 -> Outlined
                 ElevationTokens.Level2 -> Elevated
                 else -> default

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingRendererPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingRendererPreference.kt
@@ -7,8 +7,8 @@ import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import me.ash.reader.R
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.readingRenderer
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.readingRenderer
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -21,7 +21,7 @@ sealed class ReadingRendererPreference(val value: Int) : Preference() {
 
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
-            context.dataStore.put(DataStoreKey.readingRenderer, value)
+            context.dataStore.put(PreferencesKey.readingRenderer, value)
         }
     }
 
@@ -38,7 +38,7 @@ sealed class ReadingRendererPreference(val value: Int) : Preference() {
         val values = listOf(WebView, NativeComponent)
 
         fun fromPreferences(preferences: Preferences) =
-            when (preferences[DataStoreKey.keys[readingRenderer]?.key as Preferences.Key<Int>]) {
+            when (preferences[PreferencesKey.keys[readingRenderer]?.key as Preferences.Key<Int>]) {
                 0 -> WebView
                 1 -> NativeComponent
                 else -> default

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingSubheadAlignPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingSubheadAlignPreference.kt
@@ -7,8 +7,8 @@ import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import me.ash.reader.R
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.readingSubheadAlign
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.readingSubheadAlign
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -24,7 +24,7 @@ sealed class ReadingSubheadAlignPreference(val value: Int) : Preference() {
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
             context.dataStore.put(
-                DataStoreKey.readingSubheadAlign,
+                PreferencesKey.readingSubheadAlign,
                 value
             )
         }
@@ -60,7 +60,7 @@ sealed class ReadingSubheadAlignPreference(val value: Int) : Preference() {
         val values = listOf(Start, End, Center, Justify)
 
         fun fromPreferences(preferences: Preferences): ReadingSubheadAlignPreference =
-            when (preferences[DataStoreKey.keys[readingSubheadAlign]?.key as Preferences.Key<Int>]) {
+            when (preferences[PreferencesKey.keys[readingSubheadAlign]?.key as Preferences.Key<Int>]) {
                 0 -> Start
                 1 -> End
                 2 -> Center

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingSubheadBoldPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingSubheadBoldPreference.kt
@@ -5,8 +5,8 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.readingSubheadBold
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.readingSubheadBold
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -20,7 +20,7 @@ sealed class ReadingSubheadBoldPreference(val value: Boolean) : Preference() {
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
             context.dataStore.put(
-                DataStoreKey.readingSubheadBold,
+                PreferencesKey.readingSubheadBold,
                 value
             )
         }
@@ -32,7 +32,7 @@ sealed class ReadingSubheadBoldPreference(val value: Boolean) : Preference() {
         val values = listOf(ON, OFF)
 
         fun fromPreferences(preferences: Preferences) =
-            when (preferences[DataStoreKey.keys[readingSubheadBold]?.key as Preferences.Key<Boolean>]) {
+            when (preferences[PreferencesKey.keys[readingSubheadBold]?.key as Preferences.Key<Boolean>]) {
                 true -> ON
                 false -> OFF
                 else -> default

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingSubheadUpperCasePreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingSubheadUpperCasePreference.kt
@@ -5,8 +5,8 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.readingSubheadUpperCase
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.readingSubheadUpperCase
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -20,7 +20,7 @@ sealed class ReadingSubheadUpperCasePreference(val value: Boolean) : Preference(
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
             context.dataStore.put(
-                DataStoreKey.readingSubheadUpperCase,
+                PreferencesKey.readingSubheadUpperCase,
                 value
             )
         }
@@ -32,7 +32,7 @@ sealed class ReadingSubheadUpperCasePreference(val value: Boolean) : Preference(
         val values = listOf(ON, OFF)
 
         fun fromPreferences(preferences: Preferences) =
-            when (preferences[DataStoreKey.keys[readingSubheadUpperCase]?.key as Preferences.Key<Boolean>]) {
+            when (preferences[PreferencesKey.keys[readingSubheadUpperCase]?.key as Preferences.Key<Boolean>]) {
                 true -> ON
                 false -> OFF
                 else -> default

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingTextAlignPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingTextAlignPreference.kt
@@ -8,8 +8,8 @@ import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import me.ash.reader.R
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.readingTextAlign
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.readingTextAlign
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -25,7 +25,7 @@ sealed class ReadingTextAlignPreference(val value: Int) : Preference() {
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
             context.dataStore.put(
-                DataStoreKey.readingTextAlign,
+                PreferencesKey.readingTextAlign,
                 value
             )
         }
@@ -69,7 +69,7 @@ sealed class ReadingTextAlignPreference(val value: Int) : Preference() {
         val values = listOf(Start, End, Center, Justify)
 
         fun fromPreferences(preferences: Preferences): ReadingTextAlignPreference =
-            when (preferences[DataStoreKey.keys[readingTextAlign]?.key as Preferences.Key<Int>]) {
+            when (preferences[PreferencesKey.keys[readingTextAlign]?.key as Preferences.Key<Int>]) {
                 0 -> Start
                 1 -> End
                 2 -> Center

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingTextBoldPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingTextBoldPreference.kt
@@ -5,8 +5,8 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.readingTextBold
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.readingTextBold
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -20,7 +20,7 @@ sealed class ReadingTextBoldPreference(val value: Boolean) : Preference() {
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
             context.dataStore.put(
-                DataStoreKey.readingTextBold,
+                PreferencesKey.readingTextBold,
                 value
             )
         }
@@ -32,7 +32,7 @@ sealed class ReadingTextBoldPreference(val value: Boolean) : Preference() {
         val values = listOf(ON, OFF)
 
         fun fromPreferences(preferences: Preferences) =
-            when (preferences[DataStoreKey.keys[readingTextBold]?.key as Preferences.Key<Boolean>]) {
+            when (preferences[PreferencesKey.keys[readingTextBold]?.key as Preferences.Key<Boolean>]) {
                 true -> ON
                 false -> OFF
                 else -> default

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingTextFontSizePreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingTextFontSizePreference.kt
@@ -5,8 +5,8 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.readingTextFontSize
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.readingTextFontSize
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -18,10 +18,10 @@ object ReadingTextFontSizePreference {
 
     fun put(context: Context, scope: CoroutineScope, value: Int) {
         scope.launch {
-            context.dataStore.put(DataStoreKey.readingTextFontSize, value)
+            context.dataStore.put(PreferencesKey.readingTextFontSize, value)
         }
     }
 
     fun fromPreferences(preferences: Preferences) =
-        preferences[DataStoreKey.keys[readingTextFontSize]?.key as Preferences.Key<Int>] ?: default
+        preferences[PreferencesKey.keys[readingTextFontSize]?.key as Preferences.Key<Int>] ?: default
 }

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingTextHorizontalPaddingPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingTextHorizontalPaddingPreference.kt
@@ -5,8 +5,8 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.readingTextHorizontalPadding
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.readingTextHorizontalPadding
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -19,10 +19,10 @@ object ReadingTextHorizontalPaddingPreference {
 
     fun put(context: Context, scope: CoroutineScope, value: Int) {
         scope.launch {
-            context.dataStore.put(DataStoreKey.readingTextHorizontalPadding, value)
+            context.dataStore.put(PreferencesKey.readingTextHorizontalPadding, value)
         }
     }
 
     fun fromPreferences(preferences: Preferences) =
-        preferences[DataStoreKey.keys[readingTextHorizontalPadding]?.key as Preferences.Key<Int>] ?: default
+        preferences[PreferencesKey.keys[readingTextHorizontalPadding]?.key as Preferences.Key<Int>] ?: default
 }

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingTextLetterSpacingPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingTextLetterSpacingPreference.kt
@@ -5,8 +5,8 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.readingTextLetterSpacing
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.readingTextLetterSpacing
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -18,10 +18,10 @@ object ReadingTextLetterSpacingPreference {
 
     fun put(context: Context, scope: CoroutineScope, value: Float) {
         scope.launch {
-            context.dataStore.put(DataStoreKey.readingTextLetterSpacing, value)
+            context.dataStore.put(PreferencesKey.readingTextLetterSpacing, value)
         }
     }
 
     fun fromPreferences(preferences: Preferences) =
-        preferences[DataStoreKey.keys[readingTextLetterSpacing]?.key as Preferences.Key<Float>] ?: default
+        preferences[PreferencesKey.keys[readingTextLetterSpacing]?.key as Preferences.Key<Float>] ?: default
 }

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingTextLineHeightPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingTextLineHeightPreference.kt
@@ -5,8 +5,8 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.readingTextLineHeight
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.readingTextLineHeight
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -18,12 +18,12 @@ data object ReadingTextLineHeightPreference {
 
     fun put(context: Context, scope: CoroutineScope, value: Float) {
         scope.launch {
-            context.dataStore.put(DataStoreKey.readingTextLineHeight, value)
+            context.dataStore.put(PreferencesKey.readingTextLineHeight, value)
         }
     }
 
     fun Float.coerceToRange() = coerceIn(range)
 
     fun fromPreferences(preferences: Preferences) =
-        preferences[DataStoreKey.keys[readingTextLineHeight]?.key as Preferences.Key<Float>] ?: default
+        preferences[PreferencesKey.keys[readingTextLineHeight]?.key as Preferences.Key<Float>] ?: default
 }

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingThemePreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingThemePreference.kt
@@ -6,8 +6,8 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.readingTheme
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.readingTheme
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -24,7 +24,7 @@ sealed class ReadingThemePreference(val value: Int) : Preference() {
 
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
-            context.dataStore.put(DataStoreKey.readingTheme, value)
+            context.dataStore.put(PreferencesKey.readingTheme, value)
         }
     }
 
@@ -125,7 +125,7 @@ sealed class ReadingThemePreference(val value: Int) : Preference() {
         val values = listOf(MaterialYou, Reeder, Paper, Custom)
 
         fun fromPreferences(preferences: Preferences): ReadingThemePreference =
-            when (preferences[DataStoreKey.keys[readingTheme]?.key as Preferences.Key<Int>]) {
+            when (preferences[PreferencesKey.keys[readingTheme]?.key as Preferences.Key<Int>]) {
                 0 -> MaterialYou
                 1 -> Reeder
                 2 -> Paper

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingTitleAlignPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingTitleAlignPreference.kt
@@ -8,8 +8,8 @@ import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import me.ash.reader.R
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.readingTitleAlign
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.readingTitleAlign
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -25,7 +25,7 @@ sealed class ReadingTitleAlignPreference(val value: Int) : Preference() {
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
             context.dataStore.put(
-                DataStoreKey.readingTitleAlign,
+                PreferencesKey.readingTitleAlign,
                 value
             )
         }
@@ -55,7 +55,7 @@ sealed class ReadingTitleAlignPreference(val value: Int) : Preference() {
         val values = listOf(Start, End, Center, Justify)
 
         fun fromPreferences(preferences: Preferences): ReadingTitleAlignPreference =
-            when (preferences[DataStoreKey.keys[readingTitleAlign]?.key as Preferences.Key<Int>]) {
+            when (preferences[PreferencesKey.keys[readingTitleAlign]?.key as Preferences.Key<Int>]) {
                 0 -> Start
                 1 -> End
                 2 -> Center

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingTitleBoldPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingTitleBoldPreference.kt
@@ -5,8 +5,8 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.readingTitleBold
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.readingTitleBold
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -20,7 +20,7 @@ sealed class ReadingTitleBoldPreference(val value: Boolean) : Preference() {
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
             context.dataStore.put(
-                DataStoreKey.readingTitleBold,
+                PreferencesKey.readingTitleBold,
                 value
             )
         }
@@ -32,7 +32,7 @@ sealed class ReadingTitleBoldPreference(val value: Boolean) : Preference() {
         val values = listOf(ON, OFF)
 
         fun fromPreferences(preferences: Preferences) =
-            when (preferences[DataStoreKey.keys[readingTitleBold]?.key as Preferences.Key<Boolean>]) {
+            when (preferences[PreferencesKey.keys[readingTitleBold]?.key as Preferences.Key<Boolean>]) {
                 true -> ON
                 false -> OFF
                 else -> default

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingTitleUpperCasePreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/ReadingTitleUpperCasePreference.kt
@@ -5,8 +5,8 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.readingTitleUpperCase
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.readingTitleUpperCase
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -20,7 +20,7 @@ sealed class ReadingTitleUpperCasePreference(val value: Boolean) : Preference() 
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
             context.dataStore.put(
-                DataStoreKey.readingTitleUpperCase,
+                PreferencesKey.readingTitleUpperCase,
                 value
             )
         }
@@ -32,7 +32,7 @@ sealed class ReadingTitleUpperCasePreference(val value: Boolean) : Preference() 
         val values = listOf(ON, OFF)
 
         fun fromPreferences(preferences: Preferences) =
-            when (preferences[DataStoreKey.keys[readingTitleUpperCase]?.key as Preferences.Key<Boolean>]) {
+            when (preferences[PreferencesKey.keys[readingTitleUpperCase]?.key as Preferences.Key<Boolean>]) {
                 true -> ON
                 false -> OFF
                 else -> default

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/SettingsProvider.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/SettingsProvider.kt
@@ -17,7 +17,7 @@ import me.ash.reader.infrastructure.datastore.get
 import me.ash.reader.infrastructure.datastore.getOrDefault
 import me.ash.reader.infrastructure.di.ApplicationScope
 import me.ash.reader.infrastructure.di.IODispatcher
-import me.ash.reader.ui.ext.DataStoreKey
+import me.ash.reader.ui.ext.PreferencesKey
 import me.ash.reader.ui.ext.collectAsStateValue
 import me.ash.reader.ui.ext.dataStore
 import javax.inject.Inject

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/SharedContentPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/SharedContentPreference.kt
@@ -8,8 +8,8 @@ import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import me.ash.reader.R
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.sharedContent
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.sharedContent
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.orNotEmpty
 import me.ash.reader.ui.ext.put
@@ -23,7 +23,7 @@ sealed class SharedContentPreference(val value: Int) : Preference() {
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
             context.dataStore.put(
-                DataStoreKey.sharedContent,
+                PreferencesKey.sharedContent,
                 value
             )
         }
@@ -56,7 +56,7 @@ sealed class SharedContentPreference(val value: Int) : Preference() {
         val values = listOf(OnlyLink, TitleAndLink)
 
         fun fromPreferences(preferences: Preferences): SharedContentPreference =
-            when (preferences[DataStoreKey.keys[sharedContent]?.key as Preferences.Key<Int>]) {
+            when (preferences[PreferencesKey.keys[sharedContent]?.key as Preferences.Key<Int>]) {
                 0 -> OnlyLink
                 1 -> TitleAndLink
                 else -> default

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/SkipVersionNumberPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/SkipVersionNumberPreference.kt
@@ -8,8 +8,8 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
 import me.ash.reader.domain.model.general.Version
 import me.ash.reader.domain.model.general.toVersion
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.skipVersionNumber
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.skipVersionNumber
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -21,10 +21,10 @@ object SkipVersionNumberPreference {
 
     fun put(context: Context, scope: CoroutineScope, value: String) {
         scope.launch(Dispatchers.IO) {
-            context.dataStore.put(DataStoreKey.skipVersionNumber, value)
+            context.dataStore.put(PreferencesKey.skipVersionNumber, value)
         }
     }
 
     fun fromPreferences(preferences: Preferences) =
-        preferences[DataStoreKey.keys[skipVersionNumber]?.key as Preferences.Key<String>].toVersion()
+        preferences[PreferencesKey.keys[skipVersionNumber]?.key as Preferences.Key<String>].toVersion()
 }

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/SortUnreadItemsPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/SortUnreadItemsPreference.kt
@@ -9,8 +9,8 @@ import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import me.ash.reader.R
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.flowSortUnreadArticles
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.flowSortUnreadArticles
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -44,7 +44,7 @@ sealed class SortUnreadArticlesPreference(val value: Boolean) : Preference() {
         val values = listOf(Latest, Earliest)
 
         fun fromPreferences(preferences: Preferences) =
-            when (preferences[DataStoreKey.keys[flowSortUnreadArticles]?.key as Preferences.Key<Boolean>]) {
+            when (preferences[PreferencesKey.keys[flowSortUnreadArticles]?.key as Preferences.Key<Boolean>]) {
                 true -> Earliest
                 false -> Latest
                 else -> default

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/SwipeActionPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/SwipeActionPreference.kt
@@ -8,9 +8,9 @@ import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
 import me.ash.reader.R
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.swipeEndAction
-import me.ash.reader.ui.ext.DataStoreKey.Companion.swipeStartAction
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.swipeEndAction
+import me.ash.reader.ui.ext.PreferencesKey.Companion.swipeStartAction
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -26,7 +26,7 @@ sealed class SwipeEndActionPreference(val action: Int) : Preference() {
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
             context.dataStore.put(
-                DataStoreKey.swipeEndAction, action
+                PreferencesKey.swipeEndAction, action
             )
         }
     }
@@ -52,7 +52,7 @@ sealed class SwipeEndActionPreference(val action: Int) : Preference() {
         )
 
         fun fromPreferences(preferences: Preferences): SwipeEndActionPreference {
-            return when (preferences[DataStoreKey.keys[swipeEndAction]?.key as Preferences.Key<Int>]) {
+            return when (preferences[PreferencesKey.keys[swipeEndAction]?.key as Preferences.Key<Int>]) {
                 SwipeGestureActions.None -> None
                 SwipeGestureActions.ToggleRead -> ToggleRead
                 SwipeGestureActions.ToggleStarred -> ToggleStarred
@@ -67,7 +67,7 @@ val LocalArticleListSwipeStartAction = compositionLocalOf { SwipeStartActionPref
 sealed class SwipeStartActionPreference(val action: Int) : Preference() {
     override fun put(context: Context, scope: CoroutineScope) {
         scope.launch {
-            context.dataStore.put(DataStoreKey.swipeStartAction, action)
+            context.dataStore.put(PreferencesKey.swipeStartAction, action)
         }
     }
 
@@ -92,7 +92,7 @@ sealed class SwipeStartActionPreference(val action: Int) : Preference() {
         )
 
         fun fromPreferences(preferences: Preferences): SwipeStartActionPreference {
-            return when (preferences[DataStoreKey.keys[swipeStartAction]?.key as Preferences.Key<Int>]) {
+            return when (preferences[PreferencesKey.keys[swipeStartAction]?.key as Preferences.Key<Int>]) {
                 SwipeGestureActions.None -> None
                 SwipeGestureActions.ToggleRead -> ToggleRead
                 SwipeGestureActions.ToggleStarred -> ToggleStarred

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/ThemeIndexPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/ThemeIndexPreference.kt
@@ -6,8 +6,8 @@ import androidx.datastore.preferences.core.Preferences
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import me.ash.reader.ui.ext.DataStoreKey
-import me.ash.reader.ui.ext.DataStoreKey.Companion.themeIndex
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.themeIndex
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 
@@ -20,10 +20,10 @@ object ThemeIndexPreference {
 
     fun put(context: Context, scope: CoroutineScope, value: Int) {
         scope.launch(Dispatchers.IO) {
-            context.dataStore.put(DataStoreKey.themeIndex, value)
+            context.dataStore.put(PreferencesKey.themeIndex, value)
         }
     }
 
     fun fromPreferences(preferences: Preferences) =
-        preferences[DataStoreKey.keys[themeIndex]?.key as Preferences.Key<Int>] ?: default
+        preferences[PreferencesKey.keys[themeIndex]?.key as Preferences.Key<Int>] ?: default
 }

--- a/app/src/main/java/me/ash/reader/ui/component/base/RYScaffold.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/base/RYScaffold.kt
@@ -15,7 +15,7 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalLayoutDirection
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import me.ash.reader.ui.ext.surfaceColorAtElevation
+import me.ash.reader.ui.ext.atElevation
 import me.ash.reader.ui.theme.palette.onDark
 
 @OptIn(ExperimentalMaterial3Api::class)
@@ -34,19 +34,13 @@ fun RYScaffold(
     floatingActionButton: (@Composable () -> Unit)? = null,
     content: @Composable () -> Unit = {},
 ) {
+    val surfaceTint = MaterialTheme.colorScheme.surfaceTint
+    val topBarColor = containerColor.atElevation(surfaceTint, topBarTonalElevation)
+    val scaffoldColor = containerColor.atElevation(surfaceTint, containerTonalElevation)
+
     Scaffold(
-        modifier =
-            modifier.background(
-                MaterialTheme.colorScheme.surfaceColorAtElevation(
-                    topBarTonalElevation,
-                    color = containerColor,
-                )
-            ),
-        containerColor =
-            MaterialTheme.colorScheme.surfaceColorAtElevation(
-                containerTonalElevation,
-                color = containerColor,
-            ) onDark MaterialTheme.colorScheme.surface,
+        modifier = modifier.background(topBarColor),
+        containerColor = scaffoldColor onDark MaterialTheme.colorScheme.surface,
         topBar = {
             if (topBar != null) topBar()
             else if (navigationIcon != null || actions != null) {
@@ -56,10 +50,7 @@ fun RYScaffold(
                     actions = { actions?.invoke(this) },
                     colors =
                         TopAppBarDefaults.topAppBarColors(
-                            containerColor =
-                                MaterialTheme.colorScheme.surfaceColorAtElevation(
-                                    topBarTonalElevation
-                                )
+                            containerColor = topBarColor
                         ),
                 )
             }

--- a/app/src/main/java/me/ash/reader/ui/ext/DataStoreExt.kt
+++ b/app/src/main/java/me/ash/reader/ui/ext/DataStoreExt.kt
@@ -88,8 +88,12 @@ fun <T> DataStore<Preferences>.get(key: String): T? {
                     throw exception
                 }
             }
-            .map { it[PreferencesKey.keys[key]?.key as Preferences.Key<T>] }
-            .first() as T
+            .map { preferences ->
+                PreferencesKey.keys[key]?.let { typedKey ->
+                    preferences[typedKey.key as Preferences.Key<T>]
+                }
+            }
+            .first()
     }
 }
 

--- a/app/src/main/java/me/ash/reader/ui/ext/DataStoreExt.kt
+++ b/app/src/main/java/me/ash/reader/ui/ext/DataStoreExt.kt
@@ -25,27 +25,27 @@ import kotlinx.coroutines.withContext
 val Context.dataStore: DataStore<Preferences> by preferencesDataStore(name = "settings")
 
 val Context.skipVersionNumber: String
-    get() = this.dataStore.get(DataStoreKey.skipVersionNumber) ?: ""
+    get() = this.dataStore.get(PreferencesKey.skipVersionNumber) ?: ""
 val Context.isFirstLaunch: Boolean
-    get() = this.dataStore.get(DataStoreKey.isFirstLaunch) ?: true
+    get() = this.dataStore.get(PreferencesKey.isFirstLaunch) ?: true
 
 @Deprecated("Use AccountService to retrieve the current account")
 val Context.currentAccountId: Int
-    get() = this.dataStore.get(DataStoreKey.currentAccountId) ?: 1
+    get() = this.dataStore.get(PreferencesKey.currentAccountId) ?: 1
 @Deprecated("Use AccountService to retrieve the current account")
 val Context.currentAccountType: Int
-    get() = this.dataStore.get(DataStoreKey.currentAccountType) ?: 1
+    get() = this.dataStore.get(PreferencesKey.currentAccountType) ?: 1
 
 val Context.initialPage: Int
-    get() = this.dataStore.get(DataStoreKey.initialPage) ?: 0
+    get() = this.dataStore.get(PreferencesKey.initialPage) ?: 0
 val Context.initialFilter: Int
-    get() = this.dataStore.get(DataStoreKey.initialFilter) ?: 2
+    get() = this.dataStore.get(PreferencesKey.initialFilter) ?: 2
 
 val Context.languages: Int
-    get() = this.dataStore.get(DataStoreKey.languages) ?: 0
+    get() = this.dataStore.get(PreferencesKey.languages) ?: 0
 
 suspend fun DataStore<Preferences>.put(dataStoreKeys: String, value: Any) {
-    val key = DataStoreKey.keys[dataStoreKeys]?.key ?: return
+    val key = PreferencesKey.keys[dataStoreKeys]?.key ?: return
     this.edit {
         withContext(Dispatchers.IO) {
             when (value) {
@@ -88,7 +88,7 @@ fun <T> DataStore<Preferences>.get(key: String): T? {
                     throw exception
                 }
             }
-            .map { it[DataStoreKey.keys[key]?.key as Preferences.Key<T>] }
+            .map { it[PreferencesKey.keys[key]?.key as Preferences.Key<T>] }
             .first() as T
     }
 }
@@ -281,247 +281,11 @@ sealed interface PreferencesKey {
     }
 }
 
-// todo: remove
-@Deprecated("Use the type-safe PreferencesKey instead")
-@Suppress("ConstPropertyName")
-data class DataStoreKey<T>(val key: Preferences.Key<T>, val type: Class<T>) {
-    companion object {
-        const val isFirstLaunch = "isFirstLaunch"
-        const val newVersionPublishDate = "newVersionPublishDate"
-        const val newVersionLog = "newVersionLog"
-        const val newVersionSizeString = "newVersionSizeString"
-        const val newVersionDownloadUrl = "newVersionDownloadUrl"
-        const val newVersionNumber = "newVersionNumber"
-        const val skipVersionNumber = "skipVersionNumber"
-        const val currentAccountId = "currentAccountId"
-        const val currentAccountType = "currentAccountType"
-        const val themeIndex = "themeIndex"
-        const val customPrimaryColor = "customPrimaryColor"
-        const val darkTheme = "darkTheme"
-        const val amoledDarkTheme = "amoledDarkTheme"
-        const val basicFonts = "basicFonts"
-
-        // Feeds page
-        const val feedsFilterBarStyle = "feedsFilterBarStyle"
-        const val feedsFilterBarPadding = "feedsFilterBarPadding"
-        const val feedsFilterBarTonalElevation = "feedsFilterBarTonalElevation"
-        const val feedsTopBarTonalElevation = "feedsTopBarTonalElevation"
-        const val feedsGroupListExpand = "feedsGroupListExpand"
-        const val feedsGroupListTonalElevation = "feedsGroupListTonalElevation"
-
-        // Flow page
-        const val flowFilterBarStyle = "flowFilterBarStyle"
-        const val flowFilterBarPadding = "flowFilterBarPadding"
-        const val flowFilterBarTonalElevation = "flowFilterBarTonalElevation"
-        const val flowTopBarTonalElevation = "flowTopBarTonalElevation"
-        const val flowArticleListFeedIcon = "flowArticleListFeedIcon"
-        const val flowArticleListFeedName = "flowArticleListFeedName"
-        const val flowArticleListImage = "flowArticleListImage"
-        const val flowArticleListDesc = "flowArticleListDescription"
-        const val flowArticleListTime = "flowArticleListTime"
-        const val flowArticleListDateStickyHeader = "flowArticleListDateStickyHeader"
-        const val flowArticleListTonalElevation = "flowArticleListTonalElevation"
-        const val flowArticleListReadIndicator = "flowArticleListReadStatusIndicator"
-        const val flowSortUnreadArticles = "flowArticleListSortUnreadArticles"
-
-        // Reading page
-        const val readingRenderer = "readingRender"
-        const val readingBoldCharacters = "readingBoldCharacters"
-        const val readingPageTonalElevation = "readingPageTonalElevation"
-        const val readingTextFontSize = "readingTextFontSize"
-        const val readingTextLineHeight = "readingTextLineHeight"
-        const val readingTextLetterSpacing = "readingTextLetterSpacing"
-        const val readingTextHorizontalPadding = "readingTextHorizontalPadding"
-        const val readingTextBold = "readingTextBold"
-        const val readingTextAlign = "readingTextAlign"
-        const val readingTitleAlign = "readingTitleAlign"
-        const val readingSubheadAlign = "readingSubheadAlign"
-        const val readingTheme = "readingTheme"
-        const val readingFonts = "readingFonts"
-        const val readingAutoHideToolbar = "readingAutoHideToolbar"
-        const val readingTitleBold = "readingTitleBold"
-        const val readingSubheadBold = "readingSubheadBold"
-        const val readingTitleUpperCase = "readingTitleUpperCase"
-        const val readingSubheadUpperCase = "readingSubheadUpperCase"
-        const val readingImageMaximize = "readingImageMaximize"
-        const val readingImageHorizontalPadding = "readingImageHorizontalPadding"
-        const val readingImageRoundedCorners = "readingImageRoundedCorners"
-
-        // Interaction
-        const val initialPage = "initialPage"
-        const val initialFilter = "initialFilter"
-        const val swipeStartAction = "swipeStartAction"
-        const val swipeEndAction = "swipeEndAction"
-        const val markAsReadOnScroll = "markAsReadOnScroll"
-        const val hideEmptyGroups = "hideEmptyGroups"
-        const val pullToLoadNextFeed = "pullToLoadNextFeed"
-        const val pullToSwitchArticle = "pullToSwitchArticle"
-        const val openLink = "openLink"
-        const val openLinkAppSpecificBrowser = "openLinkAppSpecificBrowser"
-        const val sharedContent = "sharedContent"
-
-        // Languages
-        const val languages = "languages"
-
-        val keys: MutableMap<String, DataStoreKey<*>> =
-            mutableMapOf(
-                // Version
-                isFirstLaunch to
-                    DataStoreKey(booleanPreferencesKey(isFirstLaunch), Boolean::class.java),
-                newVersionPublishDate to
-                    DataStoreKey(stringPreferencesKey(newVersionPublishDate), String::class.java),
-                newVersionLog to
-                    DataStoreKey(stringPreferencesKey(newVersionLog), String::class.java),
-                newVersionSizeString to
-                    DataStoreKey(stringPreferencesKey(newVersionSizeString), String::class.java),
-                newVersionDownloadUrl to
-                    DataStoreKey(stringPreferencesKey(newVersionDownloadUrl), String::class.java),
-                newVersionNumber to
-                    DataStoreKey(stringPreferencesKey(newVersionNumber), String::class.java),
-                skipVersionNumber to
-                    DataStoreKey(stringPreferencesKey(skipVersionNumber), String::class.java),
-                currentAccountId to
-                    DataStoreKey(intPreferencesKey(currentAccountId), Int::class.java),
-                currentAccountType to
-                    DataStoreKey(intPreferencesKey(currentAccountType), Int::class.java),
-                themeIndex to DataStoreKey(intPreferencesKey(themeIndex), Int::class.java),
-                customPrimaryColor to
-                    DataStoreKey(stringPreferencesKey(customPrimaryColor), String::class.java),
-                darkTheme to DataStoreKey(intPreferencesKey(darkTheme), Int::class.java),
-                amoledDarkTheme to
-                    DataStoreKey(booleanPreferencesKey(amoledDarkTheme), Boolean::class.java),
-                basicFonts to DataStoreKey(intPreferencesKey(basicFonts), Int::class.java),
-                // Feeds page
-                feedsFilterBarStyle to
-                    DataStoreKey(intPreferencesKey(feedsFilterBarStyle), Int::class.java),
-                feedsFilterBarPadding to
-                    DataStoreKey(intPreferencesKey(feedsFilterBarPadding), Int::class.java),
-                feedsFilterBarTonalElevation to
-                    DataStoreKey(intPreferencesKey(feedsFilterBarTonalElevation), Int::class.java),
-                feedsTopBarTonalElevation to
-                    DataStoreKey(intPreferencesKey(feedsTopBarTonalElevation), Int::class.java),
-                feedsGroupListExpand to
-                    DataStoreKey(booleanPreferencesKey(feedsGroupListExpand), Boolean::class.java),
-                feedsGroupListTonalElevation to
-                    DataStoreKey(intPreferencesKey(feedsGroupListTonalElevation), Int::class.java),
-                // Flow page
-                flowFilterBarStyle to
-                    DataStoreKey(intPreferencesKey(flowFilterBarStyle), Int::class.java),
-                flowFilterBarPadding to
-                    DataStoreKey(intPreferencesKey(flowFilterBarPadding), Int::class.java),
-                flowFilterBarTonalElevation to
-                    DataStoreKey(intPreferencesKey(flowFilterBarTonalElevation), Int::class.java),
-                flowTopBarTonalElevation to
-                    DataStoreKey(intPreferencesKey(flowTopBarTonalElevation), Int::class.java),
-                flowArticleListFeedIcon to
-                    DataStoreKey(
-                        booleanPreferencesKey(flowArticleListFeedIcon),
-                        Boolean::class.java,
-                    ),
-                flowArticleListFeedName to
-                    DataStoreKey(
-                        booleanPreferencesKey(flowArticleListFeedName),
-                        Boolean::class.java,
-                    ),
-                flowArticleListImage to
-                    DataStoreKey(booleanPreferencesKey(flowArticleListImage), Boolean::class.java),
-                flowArticleListDesc to
-                    DataStoreKey(booleanPreferencesKey(flowArticleListDesc), Boolean::class.java),
-                flowArticleListTime to
-                    DataStoreKey(booleanPreferencesKey(flowArticleListTime), Boolean::class.java),
-                flowArticleListDateStickyHeader to
-                    DataStoreKey(
-                        booleanPreferencesKey(flowArticleListDateStickyHeader),
-                        Boolean::class.java,
-                    ),
-                flowArticleListTonalElevation to
-                    DataStoreKey(intPreferencesKey(flowArticleListTonalElevation), Int::class.java),
-                flowArticleListReadIndicator to
-                    DataStoreKey(intPreferencesKey(flowArticleListReadIndicator), Int::class.java),
-                flowSortUnreadArticles to
-                    DataStoreKey(
-                        booleanPreferencesKey(flowSortUnreadArticles),
-                        Boolean::class.java,
-                    ),
-                // Reading page
-                readingRenderer to
-                    DataStoreKey(intPreferencesKey(readingRenderer), Int::class.java),
-                readingBoldCharacters to
-                    DataStoreKey(booleanPreferencesKey(readingBoldCharacters), Boolean::class.java),
-                readingPageTonalElevation to
-                    DataStoreKey(intPreferencesKey(readingPageTonalElevation), Int::class.java),
-                readingTextFontSize to
-                    DataStoreKey(intPreferencesKey(readingTextFontSize), Int::class.java),
-                readingTextLineHeight to
-                    DataStoreKey(floatPreferencesKey(readingTextLineHeight), Float::class.java),
-                readingTextLetterSpacing to
-                    DataStoreKey(floatPreferencesKey(readingTextLetterSpacing), Float::class.java),
-                readingTextHorizontalPadding to
-                    DataStoreKey(intPreferencesKey(readingTextHorizontalPadding), Int::class.java),
-                readingTextBold to
-                    DataStoreKey(booleanPreferencesKey(readingTextBold), Boolean::class.java),
-                readingTextAlign to
-                    DataStoreKey(intPreferencesKey(readingTextAlign), Int::class.java),
-                readingTitleAlign to
-                    DataStoreKey(intPreferencesKey(readingTitleAlign), Int::class.java),
-                readingSubheadAlign to
-                    DataStoreKey(intPreferencesKey(readingSubheadAlign), Int::class.java),
-                readingTheme to DataStoreKey(intPreferencesKey(readingTheme), Int::class.java),
-                readingFonts to DataStoreKey(intPreferencesKey(readingFonts), Int::class.java),
-                readingAutoHideToolbar to
-                    DataStoreKey(
-                        booleanPreferencesKey(readingAutoHideToolbar),
-                        Boolean::class.java,
-                    ),
-                readingTitleBold to
-                    DataStoreKey(booleanPreferencesKey(readingTitleBold), Boolean::class.java),
-                readingSubheadBold to
-                    DataStoreKey(booleanPreferencesKey(readingSubheadBold), Boolean::class.java),
-                readingTitleUpperCase to
-                    DataStoreKey(booleanPreferencesKey(readingTitleUpperCase), Boolean::class.java),
-                readingSubheadUpperCase to
-                    DataStoreKey(
-                        booleanPreferencesKey(readingSubheadUpperCase),
-                        Boolean::class.java,
-                    ),
-                readingImageMaximize to
-                    DataStoreKey(booleanPreferencesKey(readingImageMaximize), Boolean::class.java),
-                readingImageHorizontalPadding to
-                    DataStoreKey(intPreferencesKey(readingImageHorizontalPadding), Int::class.java),
-                readingImageRoundedCorners to
-                    DataStoreKey(intPreferencesKey(readingImageRoundedCorners), Int::class.java),
-                // Interaction
-                initialPage to DataStoreKey(intPreferencesKey(initialPage), Int::class.java),
-                initialFilter to DataStoreKey(intPreferencesKey(initialFilter), Int::class.java),
-                swipeStartAction to
-                    DataStoreKey(intPreferencesKey(swipeStartAction), Int::class.java),
-                swipeEndAction to DataStoreKey(intPreferencesKey(swipeEndAction), Int::class.java),
-                markAsReadOnScroll to
-                    DataStoreKey(booleanPreferencesKey(markAsReadOnScroll), Boolean::class.java),
-                hideEmptyGroups to
-                    DataStoreKey(booleanPreferencesKey(hideEmptyGroups), Boolean::class.java),
-                pullToLoadNextFeed to
-                    DataStoreKey(booleanPreferencesKey(pullToLoadNextFeed), Boolean::class.java),
-                pullToSwitchArticle to
-                    DataStoreKey(booleanPreferencesKey(pullToSwitchArticle), Boolean::class.java),
-                openLink to DataStoreKey(intPreferencesKey(openLink), Int::class.java),
-                openLinkAppSpecificBrowser to
-                    DataStoreKey(
-                        stringPreferencesKey(openLinkAppSpecificBrowser),
-                        String::class.java,
-                    ),
-                sharedContent to DataStoreKey(intPreferencesKey(sharedContent), Int::class.java),
-                // Languages
-                languages to DataStoreKey(intPreferencesKey(languages), Int::class.java),
-            )
-    }
-}
-
 val ignorePreferencesOnExportAndImport =
     listOf(
-        DataStoreKey.currentAccountId,
-        DataStoreKey.currentAccountType,
-        DataStoreKey.isFirstLaunch,
+        PreferencesKey.currentAccountId,
+        PreferencesKey.currentAccountType,
+        PreferencesKey.isFirstLaunch,
     )
 
 suspend fun Context.fromDataStoreToJSONString(): String {

--- a/app/src/main/java/me/ash/reader/ui/page/settings/tips/TipsAndSupportPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/tips/TipsAndSupportPage.kt
@@ -65,7 +65,7 @@ import me.ash.reader.R
 import me.ash.reader.infrastructure.preference.OpenLinkPreference
 import me.ash.reader.ui.component.base.FeedbackIconButton
 import me.ash.reader.ui.component.base.RYScaffold
-import me.ash.reader.ui.ext.DataStoreKey
+import me.ash.reader.ui.ext.PreferencesKey
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.getCurrentVersion
 import me.ash.reader.ui.ext.openURL
@@ -180,7 +180,7 @@ fun TipsAndSupportPage(
                                         {
                                             context.showToast(context.getString(R.string.checking_updates))
                                             context.dataStore.put(
-                                                DataStoreKey.skipVersionNumber,
+                                                PreferencesKey.skipVersionNumber,
                                                 ""
                                             )
                                         },

--- a/app/src/main/java/me/ash/reader/ui/page/startup/StartupPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/startup/StartupPage.kt
@@ -34,7 +34,7 @@ import me.ash.reader.ui.component.base.DynamicSVGImage
 import me.ash.reader.ui.component.base.RYDialog
 import me.ash.reader.ui.component.base.RYScaffold
 import me.ash.reader.ui.component.base.Tips
-import me.ash.reader.ui.ext.DataStoreKey
+import me.ash.reader.ui.ext.PreferencesKey
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.put
 import me.ash.reader.ui.page.common.RouteName
@@ -94,7 +94,7 @@ fun StartupPage(
                 modifier = Modifier.navigationBarsPadding(),
                 onClick = {
                     onNavigateToFeeds()
-                    scope.launch { context.dataStore.put(DataStoreKey.isFirstLaunch, false) }
+                    scope.launch { context.dataStore.put(PreferencesKey.isFirstLaunch, false) }
                 },
                 icon = { Icon(Icons.Rounded.CheckCircleOutline, stringResource(R.string.agree)) },
                 text = { Text(text = stringResource(R.string.agree)) },
@@ -128,7 +128,7 @@ fun StartupPage(
             TextButton(
                 onClick = {
                     onNavigateToFeeds()
-                    scope.launch { context.dataStore.put(DataStoreKey.isFirstLaunch, false) }
+                    scope.launch { context.dataStore.put(PreferencesKey.isFirstLaunch, false) }
                 }
             ) {
                 Text(text = stringResource(R.string.agree))


### PR DESCRIPTION
## What changed
This PR addresses issue #12 by removing the deprecated `DataStoreKey` abstraction from the app code and moving call sites onto the existing `PreferencesKey` registry. It also updates a few central warning sources that had straightforward replacements, including the Gradle Kotlin compiler options and the crash-report clipboard path.

## Why it changed
The build was producing a large volume of deprecation warnings, especially from the DataStore preference layer. That warning noise makes real failures harder to notice and increases the cost of future Kotlin/Compose/AndroidX upgrades.

## Root cause
The codebase had two parallel preference-key abstractions, with most call sites still using the older deprecated one. In addition, the Gradle script still used deprecated `kotlinOptions` fields and the crash report screen used an older clipboard API.

## Impact
Behavior should remain the same for stored preferences because the persisted preference names are unchanged. The main effect is a lower warning count from the DataStore-related path and removal of the deprecated Kotlin Gradle DSL warning.

## Validation
Ran:
- `./gradlew :app:compileGithubDebugKotlin --warning-mode all`

Result:
- Build succeeded.
- The previous `kotlinOptions` deprecation warning is gone.
- Remaining warnings are genuine follow-up work, including `RYScaffold`, `TextFieldDialog`, `openURL`, and other still-deprecated call sites that were not silently suppressed in this PR.

Closes #12.