### PR TITLE
fix(reader): restore mark unread from article view

### DIFF
--- a/app/src/androidTest/java/me/ash/reader/FreshRssSyncE2eTest.kt
+++ b/app/src/androidTest/java/me/ash/reader/FreshRssSyncE2eTest.kt
@@ -25,7 +25,7 @@ import me.ash.reader.infrastructure.db.AndroidDatabase
 import me.ash.reader.infrastructure.preference.InitialFilterPreference
 import me.ash.reader.infrastructure.preference.InitialPagePreference
 import me.ash.reader.infrastructure.rss.provider.greader.GoogleReaderAPI
-import me.ash.reader.ui.ext.DataStoreKey
+import me.ash.reader.ui.ext.PreferencesKey
 import me.ash.reader.ui.ext.dataStore
 import me.ash.reader.ui.ext.getDefaultGroupId
 import me.ash.reader.ui.ext.put
@@ -292,15 +292,15 @@ class FreshRssSyncE2eTest {
             database.groupDao().insert(group)
             database.feedDao().insert(feed)
             database.articleDao().insert(article)
-            targetContext.dataStore.put(DataStoreKey.isFirstLaunch, false)
-            targetContext.dataStore.put(DataStoreKey.currentAccountId, accountId)
-            targetContext.dataStore.put(DataStoreKey.currentAccountType, AccountType.FreshRSS.id)
+            targetContext.dataStore.put(PreferencesKey.isFirstLaunch, false)
+            targetContext.dataStore.put(PreferencesKey.currentAccountId, accountId)
+            targetContext.dataStore.put(PreferencesKey.currentAccountType, AccountType.FreshRSS.id)
             targetContext.dataStore.put(
-                DataStoreKey.initialPage,
+                PreferencesKey.initialPage,
                 InitialPagePreference.FlowPage.value,
             )
             targetContext.dataStore.put(
-                DataStoreKey.initialFilter,
+                PreferencesKey.initialFilter,
                 InitialFilterPreference.Unread.value,
             )
         }
@@ -330,15 +330,15 @@ class FreshRssSyncE2eTest {
             }
 
         runBlocking {
-            targetContext.dataStore.put(DataStoreKey.isFirstLaunch, false)
-            targetContext.dataStore.put(DataStoreKey.currentAccountId, accountId)
-            targetContext.dataStore.put(DataStoreKey.currentAccountType, AccountType.FreshRSS.id)
+            targetContext.dataStore.put(PreferencesKey.isFirstLaunch, false)
+            targetContext.dataStore.put(PreferencesKey.currentAccountId, accountId)
+            targetContext.dataStore.put(PreferencesKey.currentAccountType, AccountType.FreshRSS.id)
             targetContext.dataStore.put(
-                DataStoreKey.initialPage,
+                PreferencesKey.initialPage,
                 InitialPagePreference.FlowPage.value,
             )
             targetContext.dataStore.put(
-                DataStoreKey.initialFilter,
+                PreferencesKey.initialFilter,
                 InitialFilterPreference.Unread.value,
             )
         }

--- a/app/src/main/java/me/ash/reader/ui/page/adaptive/ArticleListReaderViewModel.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/adaptive/ArticleListReaderViewModel.kt
@@ -451,7 +451,9 @@ data class ReadingUiState(
     val articleWithFeed: ArticleWithFeed? = null,
     val isUnread: Boolean = false,
     val isStarred: Boolean = false,
-)
+) {
+    fun withUnreadState(isUnread: Boolean): ReadingUiState = copy(isUnread = isUnread)
+}
 
 data class ReaderState(
     val articleId: String? = null,

--- a/app/src/main/java/me/ash/reader/ui/page/adaptive/ArticleListReaderViewModel.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/adaptive/ArticleListReaderViewModel.kt
@@ -297,7 +297,8 @@ constructor(
             }
             item.run {
                 _readingUiState.update {
-                    it.copy(articleWithFeed = this, isStarred = article.isStarred, isUnread = false)
+                    ReadingUiState(articleWithFeed = this, isStarred = article.isStarred)
+                        .withUnreadState(isUnread = false)
                 }
                 _readerState.update {
                     it.copy(
@@ -368,11 +369,10 @@ constructor(
     }
 
     fun updateReadStatus(isUnread: Boolean) {
-        readingUiState.value.articleWithFeed?.let {
-            diffMapHolder.updateDiff(it, isUnread = isUnread)
-        }
-        _readingUiState.update {
-            it.copy(isUnread = diffMapHolder.checkIfUnread(it.articleWithFeed!!))
+        _readingUiState.update { state ->
+            val articleWithFeed = state.articleWithFeed ?: return@update state
+            diffMapHolder.updateDiff(articleWithFeed, isUnread = isUnread)
+            state.withUnreadState(diffMapHolder.checkIfUnread(articleWithFeed))
         }
     }
 
@@ -452,7 +452,12 @@ data class ReadingUiState(
     val isUnread: Boolean = false,
     val isStarred: Boolean = false,
 ) {
-    fun withUnreadState(isUnread: Boolean): ReadingUiState = copy(isUnread = isUnread)
+    fun withUnreadState(isUnread: Boolean): ReadingUiState =
+        copy(
+            articleWithFeed =
+                articleWithFeed?.copy(article = articleWithFeed.article.copy(isUnread = isUnread)),
+            isUnread = isUnread,
+        )
 }
 
 data class ReaderState(

--- a/app/src/main/java/me/ash/reader/ui/page/adaptive/ArticleListReaderViewModel.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/adaptive/ArticleListReaderViewModel.kt
@@ -369,9 +369,11 @@ constructor(
     }
 
     fun updateReadStatus(isUnread: Boolean) {
+        val articleWithFeed = readingUiState.value.articleWithFeed ?: return
+        diffMapHolder.updateDiff(articleWithFeed, isUnread = isUnread)
+
         _readingUiState.update { state ->
-            val articleWithFeed = state.articleWithFeed ?: return@update state
-            diffMapHolder.updateDiff(articleWithFeed, isUnread = isUnread)
+            if (state.articleWithFeed?.article?.id != articleWithFeed.article.id) return@update state
             state.withUnreadState(diffMapHolder.checkIfUnread(articleWithFeed))
         }
     }

--- a/app/src/test/java/me/ash/reader/ui/page/adaptive/ReadingUiStateTest.kt
+++ b/app/src/test/java/me/ash/reader/ui/page/adaptive/ReadingUiStateTest.kt
@@ -1,0 +1,59 @@
+package me.ash.reader.ui.page.adaptive
+
+import java.util.Date
+import me.ash.reader.domain.model.article.Article
+import me.ash.reader.domain.model.article.ArticleWithFeed
+import me.ash.reader.domain.model.feed.Feed
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ReadingUiStateTest {
+    @Test
+    fun withUnreadState_marksTheStoredArticleSnapshotAsRead() {
+        val state = ReadingUiState(articleWithFeed = unreadArticle(), isUnread = true)
+
+        val updated = state.withUnreadState(isUnread = false)
+
+        assertFalse(updated.articleWithFeed!!.article.isUnread)
+        assertFalse(updated.isUnread)
+    }
+
+    @Test
+    fun withUnreadState_marksTheStoredArticleSnapshotAsUnread() {
+        val state = ReadingUiState(articleWithFeed = readArticle(), isUnread = false)
+
+        val updated = state.withUnreadState(isUnread = true)
+
+        assertTrue(updated.articleWithFeed!!.article.isUnread)
+        assertTrue(updated.isUnread)
+    }
+
+    private fun unreadArticle(): ArticleWithFeed =
+        ArticleWithFeed(
+            article =
+                Article(
+                    id = "article",
+                    date = Date(0L),
+                    title = "Article",
+                    rawDescription = "<p>Article</p>",
+                    shortDescription = "Article",
+                    link = "https://example.com/article",
+                    feedId = "feed",
+                    accountId = 1,
+                    isUnread = true,
+                ),
+            feed = sampleFeed(),
+        )
+
+    private fun readArticle(): ArticleWithFeed = unreadArticle().copy(article = unreadArticle().article.copy(isUnread = false))
+
+    private fun sampleFeed(): Feed =
+        Feed(
+            id = "feed",
+            name = "Feed",
+            url = "https://example.com/feed",
+            groupId = "group",
+            accountId = 1,
+        )
+}

--- a/app/src/test/java/me/ash/reader/ui/page/adaptive/ReadingUiStateTest.kt
+++ b/app/src/test/java/me/ash/reader/ui/page/adaptive/ReadingUiStateTest.kt
@@ -46,7 +46,8 @@ class ReadingUiStateTest {
             feed = sampleFeed(),
         )
 
-    private fun readArticle(): ArticleWithFeed = unreadArticle().copy(article = unreadArticle().article.copy(isUnread = false))
+    private fun readArticle(): ArticleWithFeed =
+        unreadArticle().run { copy(article = article.copy(isUnread = false)) }
 
     private fun sampleFeed(): Feed =
         Feed(


### PR DESCRIPTION
## Summary
- add regression coverage for the reader unread toggle state
- keep the stored `articleWithFeed` unread flag in sync with the reader UI state
- fix the reader action path so marking an auto-read article unread is not dropped

## Testing
- `./gradlew :app:testGithubDebugUnitTest --tests me.ash.reader.ui.page.adaptive.ReadingUiStateTest`
- `./gradlew :app:compileGithubDebugAndroidTestKotlin`
- `./gradlew :app:installGithubDebug`

Closes #19.