### PR TITLE
refactor(read-state): remove double negatives from app code

### DIFF
--- a/app/src/androidTest/java/me/ash/reader/FreshRssSyncE2eTest.kt
+++ b/app/src/androidTest/java/me/ash/reader/FreshRssSyncE2eTest.kt
@@ -369,8 +369,8 @@ class FreshRssSyncE2eTest {
             "Expected article $localArticleId unread=$expectedUnread",
             waitForCondition(15_000) {
                 runBlocking {
-                    database.articleDao().queryById(localArticleId)?.article?.isUnread ==
-                        expectedUnread
+                    database.articleDao().queryById(localArticleId)?.article?.isRead ==
+                        !expectedUnread
                 }
             },
         )

--- a/app/src/main/java/me/ash/reader/domain/data/DiffMapHolder.kt
+++ b/app/src/main/java/me/ash/reader/domain/data/DiffMapHolder.kt
@@ -109,25 +109,24 @@ class DiffMapHolder @Inject constructor(
         }
     }
 
-    fun checkIfUnread(articleWithFeed: ArticleWithFeed): Boolean {
-        return diffMap[articleWithFeed.article.id]?.isUnread ?: articleWithFeed.article.isUnread
+    fun checkIfRead(articleWithFeed: ArticleWithFeed): Boolean {
+        return diffMap[articleWithFeed.article.id]?.isRead ?: articleWithFeed.article.isRead
     }
 
     /**
-     * Updates the diff map with changes to an article's read/unread status.
+     * Updates the diff map with changes to an article's read status.
      *
      * This function manages a map (`diffMap`) that tracks pending changes (diffs) to the
-     * read/unread status of articles. These changes are not immediately applied to the
+     * read status of articles. These changes are not immediately applied to the
      * underlying data store but are held in `diffMap` until a later commit operation.
      *
      * The function supports three modes of updating:
      *
-     * 1. **Toggle:** If `isUnread` is `null`, the function toggles the current read/unread
-     *    status of the article.  If the article is currently unread, it will be marked as read,
-     *    and vice-versa.
-     * 2. **Mark as Unread:** If `isUnread` is `true`, the article will be marked as unread,
+     * 1. **Toggle:** If `markRead` is `null`, the function toggles the current read
+     *    status of the article.
+     * 2. **Mark as Read:** If `markRead` is `true`, the article will be marked as read,
      *    regardless of its current status.
-     * 3. **Mark as Read:** If `isUnread` is `false`, the article will be marked as read,
+     * 3. **Mark as Unread:** If `markRead` is `false`, the article will be marked as unread,
      *    regardless of its current status.
      *
      * The function determines if a change needs to be tracked based on the current status and desired status:
@@ -135,47 +134,47 @@ class DiffMapHolder @Inject constructor(
      *  - Otherwise, the diff is added to or updated in the map.
      *
      * @param articleWithFeed The article and its associated feed data. This is used to identify the article
-     *                        and access its current read/unread state.
-     * @param isUnread An optional boolean indicating the desired read/unread status of the article.
-     *                 - `null`: Toggles the current read/unread status.
-     *                 - `true`: Marks the article as unread.
-     *                 - `false`: Marks the article as read.
+     *                        and access its current read state.
+     * @param markRead An optional boolean indicating the desired read status of the article.
+     *                 - `null`: Toggles the current read status.
+     *                 - `true`: Marks the article as read.
+     *                 - `false`: Marks the article as unread.
      *
      * @return A [Diff] object representing the changes made to the article.
      *
      * @see Diff
      */
     private fun updateDiffInternal(
-        articleWithFeed: ArticleWithFeed, isUnread: Boolean? = null
+        articleWithFeed: ArticleWithFeed, markRead: Boolean? = null
     ): Diff? {
         val articleId = articleWithFeed.article.id
 
         val diff = diffMap[articleId]
 
         if (diff == null) {
-            val isUnread = isUnread ?: !articleWithFeed.article.isUnread
-            if (isUnread == articleWithFeed.article.isUnread) {
+            val isRead = markRead ?: !articleWithFeed.article.isRead
+            if (isRead == articleWithFeed.article.isRead) {
                 return null
             }
             val diff = Diff(
-                isUnread = isUnread, articleWithFeed = articleWithFeed
+                isRead = isRead, articleWithFeed = articleWithFeed
             )
             diffMap[articleId] = diff
             return diff
         } else {
-            if (isUnread == null || diff.isUnread != isUnread) {
+            if (markRead == null || diff.isRead != markRead) {
                 val diff = diffMap.remove(articleId)
-                return diff?.copy(isUnread = !diff.isUnread)
+                return diff?.copy(isRead = !diff.isRead)
             }
         }
         return null
     }
 
     fun updateDiff(
-        vararg articleWithFeed: ArticleWithFeed, isUnread: Boolean? = null
+        vararg articleWithFeed: ArticleWithFeed, markRead: Boolean? = null
     ) {
         val appliedDiffs = articleWithFeed.mapNotNull {
-            updateDiffInternal(it, isUnread)
+            updateDiffInternal(it, markRead)
         }
         if (appliedDiffs.isEmpty()) return
 
@@ -191,7 +190,7 @@ class DiffMapHolder @Inject constructor(
 
     private fun appendDiffToSync(diff: Diff) {
         val syncedDiff = syncedDiffs[diff.articleId]
-        if (syncedDiff == null || syncedDiff.isUnread != diff.isUnread) {
+        if (syncedDiff == null || syncedDiff.isRead != diff.isRead) {
             pendingSyncDiffs[diff.articleId] = diff
             applicationScope.launch(ioDispatcher) {
                 toPendingReadStateOp(diff)?.let { pendingReadStateOpDao.upsert(it) }
@@ -210,8 +209,8 @@ class DiffMapHolder @Inject constructor(
         if (diffsToCommit.isEmpty()) return
 
         val diffBatch = ReadStateDiffApplier.toBatch(diffsToCommit)
-        rssService.get().batchMarkAsRead(articleIds = diffBatch.markReadIds, isUnread = false)
-        rssService.get().batchMarkAsRead(articleIds = diffBatch.markUnreadIds, isUnread = true)
+        rssService.get().batchMarkAsRead(articleIds = diffBatch.markReadIds, markRead = true)
+        rssService.get().batchMarkAsRead(articleIds = diffBatch.markUnreadIds, markRead = false)
 
         ReadStateDiffApplier.removeMatchingDiffs(
             currentDiffs = diffMap,
@@ -236,10 +235,8 @@ class DiffMapHolder @Inject constructor(
         if (!shouldSyncWithRemote) return
         if (diffs.isEmpty()) return
         val toBeSync = diffs
-        val markAsReadArticles =
-            toBeSync.filter { !it.value.isUnread }.map { it.key }.toSet()
-        val markAsUnreadArticles =
-            toBeSync.filter { it.value.isUnread }.map { it.key }.toSet()
+        val markAsReadArticles = toBeSync.filter { it.value.isRead }.map { it.key }.toSet()
+        val markAsUnreadArticles = toBeSync.filter { !it.value.isRead }.map { it.key }.toSet()
 
         val synced = syncReadStateOps(markAsReadArticles, markAsUnreadArticles)
 
@@ -279,15 +276,15 @@ class DiffMapHolder @Inject constructor(
         val queuedOps = pendingReadStateOpDao.queryByAccountId(accountId)
         if (queuedOps.isEmpty()) return
 
-        val markAsReadArticles = queuedOps.filter { !it.isUnread }.map { it.articleId }.toSet()
-        val markAsUnreadArticles = queuedOps.filter { it.isUnread }.map { it.articleId }.toSet()
+        val markAsReadArticles = queuedOps.filter { it.isRead }.map { it.articleId }.toSet()
+        val markAsUnreadArticles = queuedOps.filter { !it.isRead }.map { it.articleId }.toSet()
         val synced = syncReadStateOps(markAsReadArticles, markAsUnreadArticles)
         if (synced.isEmpty()) return
 
         pendingReadStateOpDao.deleteByArticleIds(synced)
         syncedDiffs += queuedOps
             .filter { synced.contains(it.articleId) }
-            .associate { it.articleId to Diff(it.isUnread, it.articleId, it.feedId) }
+            .associate { it.articleId to Diff(it.isRead, it.articleId, it.feedId) }
     }
 
     private suspend fun syncReadStateOps(
@@ -299,13 +296,13 @@ class DiffMapHolder @Inject constructor(
             val read = async {
                 rssService.syncReadStatus(
                     articleIds = markAsReadArticles,
-                    isUnread = false
+                    markRead = true
                 )
             }
             val unread = async {
                 rssService.syncReadStatus(
                     articleIds = markAsUnreadArticles,
-                    isUnread = true
+                    markRead = false
                 )
             }
             runCatching { read.await() }.getOrElse { emptySet() } +
@@ -327,17 +324,17 @@ class DiffMapHolder @Inject constructor(
             articleId = diff.articleId,
             accountId = accountId,
             feedId = diff.feedId,
-            isUnread = diff.isUnread,
+            isUnread = !diff.isRead,
         )
     }
 
 }
 
 data class Diff(
-    val isUnread: Boolean, val articleId: String, val feedId: String
+    val isRead: Boolean, val articleId: String, val feedId: String
 ) {
-    constructor(isUnread: Boolean, articleWithFeed: ArticleWithFeed) : this(
-        isUnread = isUnread,
+    constructor(isRead: Boolean, articleWithFeed: ArticleWithFeed) : this(
+        isRead = isRead,
         articleId = articleWithFeed.article.id,
         feedId = articleWithFeed.feed.id,
     )

--- a/app/src/main/java/me/ash/reader/domain/data/GroupWithFeedsListUseCase.kt
+++ b/app/src/main/java/me/ash/reader/domain/data/GroupWithFeedsListUseCase.kt
@@ -135,8 +135,8 @@ class GroupWithFeedsListUseCase @Inject constructor(
                 feedsFlow, unreadCountMapFlow, diffMapHolder.diffMapSnapshotFlow
             ) { groupWithFeedsList, unreadCountMap, diffMap ->
                 val result = mutableListOf<GroupWithFeed>()
-                val unreadDiffs = diffMap.values.filter { it.isUnread }
-                val readDiffs = diffMap.values.filterNot { it.isUnread }
+                val unreadDiffs = diffMap.values.filterNot { it.isRead }
+                val readDiffs = diffMap.values.filter { it.isRead }
 
                 for (groupItem in groupWithFeedsList) {
 

--- a/app/src/main/java/me/ash/reader/domain/data/ReadStateDiffApplier.kt
+++ b/app/src/main/java/me/ash/reader/domain/data/ReadStateDiffApplier.kt
@@ -8,8 +8,8 @@ internal data class ReadStateDiffBatch(
 internal object ReadStateDiffApplier {
     fun toBatch(diffs: Map<String, Diff>): ReadStateDiffBatch =
         ReadStateDiffBatch(
-            markReadIds = diffs.filter { !it.value.isUnread }.keys,
-            markUnreadIds = diffs.filter { it.value.isUnread }.keys,
+            markReadIds = diffs.filter { it.value.isRead }.keys,
+            markUnreadIds = diffs.filter { !it.value.isRead }.keys,
         )
 
     fun removeMatchingDiffs(

--- a/app/src/main/java/me/ash/reader/domain/model/article/Article.kt
+++ b/app/src/main/java/me/ash/reader/domain/model/article/Article.kt
@@ -53,4 +53,10 @@ data class Article(
 
     @Ignore
     var dateString: String? = null
+
+    var isRead: Boolean
+        get() = !isUnread
+        set(value) {
+            isUnread = !value
+        }
 }

--- a/app/src/main/java/me/ash/reader/domain/model/article/ArticleMeta.kt
+++ b/app/src/main/java/me/ash/reader/domain/model/article/ArticleMeta.kt
@@ -14,4 +14,10 @@ data class ArticleMeta(
     var isUnread: Boolean = true,
     @field:ColumnInfo
     var isStarred: Boolean = false,
-)
+) {
+    var isRead: Boolean
+        get() = !isUnread
+        set(value) {
+            isUnread = !value
+        }
+}

--- a/app/src/main/java/me/ash/reader/domain/model/article/PendingReadStateOp.kt
+++ b/app/src/main/java/me/ash/reader/domain/model/article/PendingReadStateOp.kt
@@ -21,4 +21,7 @@ data class PendingReadStateOp(
     val isUnread: Boolean,
     @ColumnInfo
     val updatedAt: Date = Date(),
-)
+) {
+    val isRead: Boolean
+        get() = !isUnread
+}

--- a/app/src/main/java/me/ash/reader/domain/repository/ArticleDao.kt
+++ b/app/src/main/java/me/ash/reader/domain/repository/ArticleDao.kt
@@ -36,7 +36,7 @@ interface ArticleDao {
 
     @Query(
         """
-        UPDATE article SET isUnread = :isUnread 
+        UPDATE article SET isUnread = :storedUnread 
         WHERE accountId = :accountId
         AND id in (:ids)
         """
@@ -44,7 +44,7 @@ interface ArticleDao {
     fun markAsReadByIdSet(
         accountId: Int,
         ids: Set<String>,
-        isUnread: Boolean,
+        storedUnread: Boolean,
     ): Int
 
     @Transaction
@@ -321,59 +321,59 @@ interface ArticleDao {
     @Transaction
     @Query(
         """
-        UPDATE article SET isUnread = :isUnread 
+        UPDATE article SET isUnread = :storedUnread 
         WHERE accountId = :accountId
         AND date < :before
-        AND isUnread != :isUnread
+        AND isUnread != :storedUnread
         """
     )
     suspend fun markAllAsRead(
         accountId: Int,
-        isUnread: Boolean,
+        storedUnread: Boolean,
         before: Date,
     )
 
     @Transaction
     @Query(
         """
-        UPDATE article SET isUnread = :isUnread 
+        UPDATE article SET isUnread = :storedUnread 
         WHERE feedId IN (
             SELECT id FROM feed 
             WHERE groupId = :groupId
         )
         AND accountId = :accountId
-        AND isUnread != :isUnread
+        AND isUnread != :storedUnread
         AND date < :before
         """
     )
     suspend fun markAllAsReadByGroupId(
         accountId: Int,
         groupId: String,
-        isUnread: Boolean,
+        storedUnread: Boolean,
         before: Date,
     )
 
     @Transaction
     @Query(
         """
-        UPDATE article SET isUnread = :isUnread 
+        UPDATE article SET isUnread = :storedUnread 
         WHERE feedId = :feedId
         AND accountId = :accountId
-        AND isUnread != :isUnread
+        AND isUnread != :storedUnread
         AND date < :before
         """
     )
     suspend fun markAllAsReadByFeedId(
         accountId: Int,
         feedId: String,
-        isUnread: Boolean,
+        storedUnread: Boolean,
         before: Date,
     )
 
     @Transaction
     @Query(
         """
-        UPDATE article SET isUnread = :isUnread 
+        UPDATE article SET isUnread = :storedUnread 
         WHERE id = :articleId
         AND accountId = :accountId
         """
@@ -381,7 +381,7 @@ interface ArticleDao {
     suspend fun markAsReadByArticleId(
         accountId: Int,
         articleId: String,
-        isUnread: Boolean,
+        storedUnread: Boolean,
     )
 
     @Query(

--- a/app/src/main/java/me/ash/reader/domain/service/AbstractRssRepository.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/AbstractRssRepository.kt
@@ -102,14 +102,14 @@ abstract class AbstractRssRepository(
         before: Date?,
         markRead: Boolean,
     ) {
-        val isUnread = !markRead
+        val storedUnread = !markRead
         val accountId = accountService.getCurrentAccountId()
         when {
             groupId != null -> {
                 articleDao.markAllAsReadByGroupId(
                     accountId = accountId,
                     groupId = groupId,
-                    isUnread = isUnread,
+                    storedUnread = storedUnread,
                     before = before ?: Date(Long.MAX_VALUE),
                 )
             }
@@ -118,29 +118,29 @@ abstract class AbstractRssRepository(
                 articleDao.markAllAsReadByFeedId(
                     accountId = accountId,
                     feedId = feedId,
-                    isUnread = isUnread,
+                    storedUnread = storedUnread,
                     before = before ?: Date(Long.MAX_VALUE),
                 )
             }
 
             articleId != null -> {
-                articleDao.markAsReadByArticleId(accountId, articleId, isUnread)
+                articleDao.markAsReadByArticleId(accountId, articleId, storedUnread)
             }
 
             else -> {
-                articleDao.markAllAsRead(accountId, isUnread, before ?: Date(Long.MAX_VALUE))
+                articleDao.markAllAsRead(accountId, storedUnread, before ?: Date(Long.MAX_VALUE))
             }
         }
     }
 
     open suspend fun batchMarkAsRead(articleIds: Set<String>, markRead: Boolean) {
         val accountId = accountService.getCurrentAccountId()
-        val isUnread = !markRead
+        val storedUnread = !markRead
         articleIds
             .takeIf { it.isNotEmpty() }
             ?.chunked(500)
             ?.forEachIndexed { index, it ->
-                articleDao.markAsReadByIdSet(accountId, it.toSet(), isUnread)
+                articleDao.markAsReadByIdSet(accountId, it.toSet(), storedUnread)
             }
     }
 

--- a/app/src/main/java/me/ash/reader/domain/service/AbstractRssRepository.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/AbstractRssRepository.kt
@@ -100,8 +100,9 @@ abstract class AbstractRssRepository(
         feedId: String?,
         articleId: String?,
         before: Date?,
-        isUnread: Boolean,
+        markRead: Boolean,
     ) {
+        val isUnread = !markRead
         val accountId = accountService.getCurrentAccountId()
         when {
             groupId != null -> {
@@ -132,8 +133,9 @@ abstract class AbstractRssRepository(
         }
     }
 
-    open suspend fun batchMarkAsRead(articleIds: Set<String>, isUnread: Boolean) {
+    open suspend fun batchMarkAsRead(articleIds: Set<String>, markRead: Boolean) {
         val accountId = accountService.getCurrentAccountId()
+        val isUnread = !markRead
         articleIds
             .takeIf { it.isNotEmpty() }
             ?.chunked(500)
@@ -142,7 +144,7 @@ abstract class AbstractRssRepository(
             }
     }
 
-    open suspend fun syncReadStatus(articleIds: Set<String>, isUnread: Boolean): Set<String> {
+    open suspend fun syncReadStatus(articleIds: Set<String>, markRead: Boolean): Set<String> {
         /* no-op */
         return emptySet()
     }

--- a/app/src/main/java/me/ash/reader/domain/service/FeverRssService.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/FeverRssService.kt
@@ -278,10 +278,14 @@ constructor(
             val articleMeta = articleDao.queryMetadataAll(accountId)
             for (meta: ArticleMeta in articleMeta) {
                 val articleId = meta.id.dollarLast()
-                val shouldBeUnread = unreadArticleIds?.contains(articleId)
+                val shouldBeRead = unreadArticleIds?.contains(articleId)?.not()
                 val shouldBeStarred = starredArticleIds?.contains(articleId)
-                if ((!meta.isRead) != shouldBeUnread) {
-                    articleDao.markAsReadByArticleId(accountId, meta.id, shouldBeUnread ?: true)
+                if (shouldBeRead != null && meta.isRead != shouldBeRead) {
+                    articleDao.markAsReadByArticleId(
+                        accountId = accountId,
+                        articleId = meta.id,
+                        storedUnread = !shouldBeRead,
+                    )
                 }
                 if (meta.isStarred != shouldBeStarred) {
                     articleDao.markAsStarredByArticleId(

--- a/app/src/main/java/me/ash/reader/domain/service/FeverRssService.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/FeverRssService.kt
@@ -335,12 +335,12 @@ constructor(
     ) {
         super.markAsRead(groupId, feedId, articleId, before, markRead)
         val feverAPI = getFeverAPI()
-        val isUnread = !markRead
+        val targetStatus = if (markRead) FeverDTO.StatusEnum.Read else FeverDTO.StatusEnum.Unread
         val beforeUnixTimestamp = (before?.time ?: Date(Long.MAX_VALUE).time) / 1000
         when {
             groupId != null -> {
                 feverAPI.markGroup(
-                    status = if (isUnread) FeverDTO.StatusEnum.Unread else FeverDTO.StatusEnum.Read,
+                    status = targetStatus,
                     id = groupId.dollarLast().toLong(),
                     before = beforeUnixTimestamp,
                 )
@@ -348,7 +348,7 @@ constructor(
 
             feedId != null -> {
                 feverAPI.markFeed(
-                    status = if (isUnread) FeverDTO.StatusEnum.Unread else FeverDTO.StatusEnum.Read,
+                    status = targetStatus,
                     id = feedId.dollarLast().toLong(),
                     before = beforeUnixTimestamp,
                 )
@@ -356,7 +356,7 @@ constructor(
 
             articleId != null -> {
                 feverAPI.markItem(
-                    status = if (isUnread) FeverDTO.StatusEnum.Unread else FeverDTO.StatusEnum.Read,
+                    status = targetStatus,
                     id = articleId.dollarLast(),
                 )
             }
@@ -364,8 +364,7 @@ constructor(
             else -> {
                 feedDao.queryAll(accountService.getCurrentAccountId()).forEach {
                     feverAPI.markFeed(
-                        status =
-                            if (isUnread) FeverDTO.StatusEnum.Unread else FeverDTO.StatusEnum.Read,
+                        status = targetStatus,
                         id = it.id.dollarLast().toLong(),
                         before = beforeUnixTimestamp,
                     )
@@ -377,14 +376,14 @@ constructor(
     @CheckResult
     override suspend fun syncReadStatus(articleIds: Set<String>, markRead: Boolean): Set<String> {
         val feverAPI = getFeverAPI()
-        val isUnread = !markRead
+        val targetStatus = if (markRead) FeverDTO.StatusEnum.Read else FeverDTO.StatusEnum.Unread
         val syncedEntries = mutableSetOf<String>()
         articleIds
             .takeIf { it.isNotEmpty() }
             ?.forEachIndexed { index, it ->
                 Log.d("RLog", "sync markAsRead: ${index}/${articleIds.size} num")
                 feverAPI.markItem(
-                    status = if (isUnread) FeverDTO.StatusEnum.Unread else FeverDTO.StatusEnum.Read,
+                    status = targetStatus,
                     id = it.dollarLast(),
                 )
                 syncedEntries += it

--- a/app/src/main/java/me/ash/reader/domain/service/FeverRssService.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/FeverRssService.kt
@@ -266,7 +266,7 @@ constructor(
                     feedDao.queryNotificationEnabled(accountId).associateBy { it.id }
                 val notificationFeedIds = notificationFeeds.keys
                 allArticles
-                    .fastFilter { it.isUnread && it.feedId in notificationFeedIds }
+                    .fastFilter { !it.isRead && it.feedId in notificationFeedIds }
                     .groupBy { it.feedId }
                     .mapKeys { (feedId, _) -> notificationFeeds[feedId]!! }
                     .forEach { (feed, articles) -> notificationHelper.notify(feed, articles) }
@@ -280,7 +280,7 @@ constructor(
                 val articleId = meta.id.dollarLast()
                 val shouldBeUnread = unreadArticleIds?.contains(articleId)
                 val shouldBeStarred = starredArticleIds?.contains(articleId)
-                if (meta.isUnread != shouldBeUnread) {
+                if ((!meta.isRead) != shouldBeUnread) {
                     articleDao.markAsReadByArticleId(accountId, meta.id, shouldBeUnread ?: true)
                 }
                 if (meta.isStarred != shouldBeStarred) {
@@ -331,10 +331,11 @@ constructor(
         feedId: String?,
         articleId: String?,
         before: Date?,
-        isUnread: Boolean,
+        markRead: Boolean,
     ) {
-        super.markAsRead(groupId, feedId, articleId, before, isUnread)
+        super.markAsRead(groupId, feedId, articleId, before, markRead)
         val feverAPI = getFeverAPI()
+        val isUnread = !markRead
         val beforeUnixTimestamp = (before?.time ?: Date(Long.MAX_VALUE).time) / 1000
         when {
             groupId != null -> {
@@ -374,8 +375,9 @@ constructor(
     }
 
     @CheckResult
-    override suspend fun syncReadStatus(articleIds: Set<String>, isUnread: Boolean): Set<String> {
+    override suspend fun syncReadStatus(articleIds: Set<String>, markRead: Boolean): Set<String> {
         val feverAPI = getFeverAPI()
+        val isUnread = !markRead
         val syncedEntries = mutableSetOf<String>()
         articleIds
             .takeIf { it.isNotEmpty() }

--- a/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
@@ -328,12 +328,12 @@ constructor(
 
             val localAllItems = articleDao.queryMetadataAll(accountId)
             val localUnreadIds =
-                localAllItems.filter { it.isUnread }.map { it.id.dollarLast() }.toSet()
+                localAllItems.filterNot { it.isRead }.map { it.id.dollarLast() }.toSet()
             val localStarredIds =
                 localAllItems.filter { it.isStarred }.map { it.id.dollarLast() }.toSet()
 
             val localReadIds =
-                localAllItems.filter { !it.isUnread }.map { it.id.dollarLast() }.toSet()
+                localAllItems.filter { it.isRead }.map { it.id.dollarLast() }.toSet()
 
             val localItemIds = localAllItems.map { it.id.dollarLast() }.toSet()
 
@@ -502,7 +502,7 @@ constructor(
                                     articleDao.insertList(it)
                                     articlesToNotify.addAll(
                                         it.fastFilter {
-                                            it.isUnread && notificationFeedIds.contains(it.feedId)
+                                            !it.isRead && notificationFeedIds.contains(it.feedId)
                                         }
                                     )
                                     deferredList.remove(deferred)
@@ -629,7 +629,7 @@ constructor(
                 )
 
             if (feed.isNotification) {
-                val articlesToNotify = items.fastFilter { it.isUnread }
+                val articlesToNotify = items.fastFilter { !it.isRead }
                 notificationHelper.notify(feed, articlesToNotify)
             }
 
@@ -817,8 +817,9 @@ constructor(
         feedId: String?,
         articleId: String?,
         before: Date?,
-        isUnread: Boolean,
+        markRead: Boolean,
     ) {
+        val isUnread = !markRead
         val accountId = accountService.getCurrentAccountId()
         val googleReaderAPI = getGoogleReaderAPI()
         val markList: List<String> =
@@ -863,7 +864,7 @@ constructor(
                         .map { it.id.dollarLast() }
                 }
             }
-        super.markAsRead(groupId, feedId, articleId, before, isUnread)
+        super.markAsRead(groupId, feedId, articleId, before, markRead)
         markList
             .takeIf { it.isNotEmpty() }
             ?.chunked(500)
@@ -877,7 +878,8 @@ constructor(
             }
     }
 
-    override suspend fun syncReadStatus(articleIds: Set<String>, isUnread: Boolean): Set<String> {
+    override suspend fun syncReadStatus(articleIds: Set<String>, markRead: Boolean): Set<String> {
+        val isUnread = !markRead
         val googleReaderAPI = getGoogleReaderAPI()
         val syncedEntries = mutableSetOf<String>()
         articleIds
@@ -897,7 +899,7 @@ constructor(
                     .onFailure { it.printStackTrace() }
                     .onSuccess {
                         syncedEntries += idList
-                        println("synced $idList to isUnread: $isUnread")
+                        println("synced $idList to markRead: $markRead")
                     }
             }
         return syncedEntries

--- a/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
@@ -387,7 +387,7 @@ constructor(
                     articleDao.markAsReadByIdSet(
                         accountId = accountId,
                         ids = it.toSet(),
-                        isUnread = false,
+                        storedUnread = false,
                     )
                 }
             }
@@ -407,7 +407,7 @@ constructor(
                     articleDao.markAsReadByIdSet(
                         accountId = accountId,
                         ids = it.toSet(),
-                        isUnread = true,
+                        storedUnread = true,
                     )
                 }
             }
@@ -651,7 +651,7 @@ constructor(
                         articleDao.markAsReadByIdSet(
                             accountId = accountId,
                             ids = it.toSet(),
-                            isUnread = false,
+                            storedUnread = false,
                         )
                     }
             }
@@ -673,7 +673,7 @@ constructor(
                         articleDao.markAsReadByIdSet(
                             accountId = accountId,
                             ids = it.toSet(),
-                            isUnread = true,
+                            storedUnread = true,
                         )
                     }
             }
@@ -819,7 +819,7 @@ constructor(
         before: Date?,
         markRead: Boolean,
     ) {
-        val isUnread = !markRead
+        val storedUnread = !markRead
         val accountId = accountService.getCurrentAccountId()
         val googleReaderAPI = getGoogleReaderAPI()
         val markList: List<String> =
@@ -829,14 +829,14 @@ constructor(
                             articleDao.queryMetadataByGroupIdWhenIsUnread(
                                 accountId,
                                 groupId,
-                                !isUnread,
+                                isUnread = !storedUnread,
                             )
                         } else {
                             articleDao.queryMetadataByGroupIdWhenIsUnread(
                                 accountId,
                                 groupId,
-                                !isUnread,
-                                before,
+                                isUnread = !storedUnread,
+                                before = before,
                             )
                         }
                         .map { it.id.dollarLast() }
@@ -844,9 +844,9 @@ constructor(
 
                 feedId != null -> {
                     if (before == null) {
-                            articleDao.queryMetadataByFeedId(accountId, feedId, !isUnread)
+                            articleDao.queryMetadataByFeedId(accountId, feedId, isUnread = !storedUnread)
                         } else {
-                            articleDao.queryMetadataByFeedId(accountId, feedId, !isUnread, before)
+                            articleDao.queryMetadataByFeedId(accountId, feedId, isUnread = !storedUnread, before = before)
                         }
                         .map { it.id.dollarLast() }
                 }
@@ -857,9 +857,9 @@ constructor(
 
                 else -> {
                     if (before == null) {
-                            articleDao.queryMetadataAll(accountId, !isUnread)
+                            articleDao.queryMetadataAll(accountId, isUnread = !storedUnread)
                         } else {
-                            articleDao.queryMetadataAll(accountId, !isUnread, before)
+                            articleDao.queryMetadataAll(accountId, isUnread = !storedUnread, before = before)
                         }
                         .map { it.id.dollarLast() }
                 }
@@ -872,14 +872,13 @@ constructor(
                 Log.d("RLog", "sync markAsRead:  ${(index * 500) + it.size}/${markList.size} num")
                 googleReaderAPI.editTag(
                     itemIds = it,
-                    mark = if (!isUnread) GoogleReaderAPI.Stream.Read.tag else null,
-                    unmark = if (isUnread) GoogleReaderAPI.Stream.Read.tag else null,
+                    mark = if (markRead) GoogleReaderAPI.Stream.Read.tag else null,
+                    unmark = if (!markRead) GoogleReaderAPI.Stream.Read.tag else null,
                 )
             }
     }
 
     override suspend fun syncReadStatus(articleIds: Set<String>, markRead: Boolean): Set<String> {
-        val isUnread = !markRead
         val googleReaderAPI = getGoogleReaderAPI()
         val syncedEntries = mutableSetOf<String>()
         articleIds
@@ -893,8 +892,8 @@ constructor(
                 googleReaderAPI
                     .editTag(
                         itemIds = idList.map { it.dollarLast() },
-                        mark = if (!isUnread) GoogleReaderAPI.Stream.Read.tag else null,
-                        unmark = if (isUnread) GoogleReaderAPI.Stream.Read.tag else null,
+                        mark = if (markRead) GoogleReaderAPI.Stream.Read.tag else null,
+                        unmark = if (!markRead) GoogleReaderAPI.Stream.Read.tag else null,
                     )
                     .onFailure { it.printStackTrace() }
                     .onSuccess {

--- a/app/src/main/java/me/ash/reader/ui/page/adaptive/ArticleListReaderViewModel.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/adaptive/ArticleListReaderViewModel.kt
@@ -145,7 +145,7 @@ constructor(
         feedId: String?,
         articleId: String?,
         conditions: MarkAsReadConditions,
-        isUnread: Boolean,
+        markRead: Boolean,
     ) {
         applicationScope.launch(ioDispatcher) {
             rssService
@@ -155,7 +155,7 @@ constructor(
                     feedId = feedId,
                     articleId = articleId,
                     before = conditions.toDate(),
-                    isUnread = isUnread,
+                    markRead = markRead,
                 )
         }
     }
@@ -176,14 +176,14 @@ constructor(
                     .map { it.articleWithFeed }
                     .filter {
                         if (isBefore) {
-                            date > it.article.date && it.article.isUnread
+                            date > it.article.date && !it.article.isRead
                         } else {
-                            date < it.article.date && it.article.isUnread
+                            date < it.article.date && !it.article.isRead
                         }
                     }
                     .distinctBy { it.article.id }
 
-            diffMapHolder.updateDiff(articleWithFeed = items.toTypedArray(), isUnread = false)
+            diffMapHolder.updateDiff(articleWithFeed = items.toTypedArray(), markRead = true)
         }
     }
 
@@ -206,7 +206,7 @@ constructor(
                     .filterIsInstance<ArticleFlowItem.Article>()
                     .map { it.articleWithFeed }
 
-            diffMapHolder.updateDiff(articleWithFeed = items.toTypedArray(), isUnread = false)
+            diffMapHolder.updateDiff(articleWithFeed = items.toTypedArray(), markRead = true)
         }
     }
 
@@ -292,13 +292,13 @@ constructor(
                     ?: (itemFromList?.articleWithFeed
                         ?: rssService.get().findArticleById(articleId)!!)
 
-            if (diffMapHolder.checkIfUnread(item)) {
-                diffMapHolder.updateDiff(item, isUnread = false)
+            if (!diffMapHolder.checkIfRead(item)) {
+                diffMapHolder.updateDiff(item, markRead = true)
             }
             item.run {
                 _readingUiState.update {
                     ReadingUiState(articleWithFeed = this, isStarred = article.isStarred)
-                        .withUnreadState(isUnread = false)
+                        .withReadState(isRead = true)
                 }
                 _readerState.update {
                     it.copy(
@@ -368,13 +368,13 @@ constructor(
         }
     }
 
-    fun updateReadStatus(isUnread: Boolean) {
+    fun updateReadStatus(markRead: Boolean) {
         val articleWithFeed = readingUiState.value.articleWithFeed ?: return
-        diffMapHolder.updateDiff(articleWithFeed, isUnread = isUnread)
+        diffMapHolder.updateDiff(articleWithFeed, markRead = markRead)
 
         _readingUiState.update { state ->
             if (state.articleWithFeed?.article?.id != articleWithFeed.article.id) return@update state
-            state.withUnreadState(diffMapHolder.checkIfUnread(articleWithFeed))
+            state.withReadState(diffMapHolder.checkIfRead(articleWithFeed))
         }
     }
 
@@ -451,14 +451,14 @@ data class FlowUiState(val pagerData: PagerData, val nextFilterState: FilterStat
 
 data class ReadingUiState(
     val articleWithFeed: ArticleWithFeed? = null,
-    val isUnread: Boolean = false,
+    val isRead: Boolean = false,
     val isStarred: Boolean = false,
 ) {
-    fun withUnreadState(isUnread: Boolean): ReadingUiState =
+    fun withReadState(isRead: Boolean): ReadingUiState =
         copy(
             articleWithFeed =
-                articleWithFeed?.copy(article = articleWithFeed.article.copy(isUnread = isUnread)),
-            isUnread = isUnread,
+                articleWithFeed?.copy(article = articleWithFeed.article.copy(isUnread = !isRead)),
+            isRead = isRead,
         )
 }
 

--- a/app/src/main/java/me/ash/reader/ui/page/home/feeds/FeedsViewModel.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/feeds/FeedsViewModel.kt
@@ -149,7 +149,7 @@ class FeedsViewModel @Inject constructor(
                 ) { diffMap, unreadCountMap ->
                     val sum = unreadCountMap.values.sum()
                     val combinedSum =
-                        sum + diffMap.values.sumOf { if (it.isUnread) 1.toInt() else -1 } // KT-46360
+                        sum + diffMap.values.sumOf { if (it.isRead) -1 else 1.toInt() } // KT-46360
                     androidStringsHelper.getQuantityString(
                         R.plurals.unread_desc,
                         combinedSum,

--- a/app/src/main/java/me/ash/reader/ui/page/home/flow/ArticleItem.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/flow/ArticleItem.kt
@@ -89,7 +89,7 @@ private const val TAG = "ArticleItem"
 fun ArticleItem(
     modifier: Modifier = Modifier,
     articleWithFeed: ArticleWithFeed,
-    isUnread: Boolean = articleWithFeed.article.isUnread,
+    isRead: Boolean = articleWithFeed.article.isRead,
     onClick: (ArticleWithFeed) -> Unit = {},
     onLongClick: (() -> Unit)? = null,
 ) {
@@ -105,7 +105,7 @@ fun ArticleItem(
         timeString = article.dateString,
         imgData = article.img,
         isStarred = article.isStarred,
-        isUnread = isUnread,
+        isRead = isRead,
         onClick = { onClick(articleWithFeed) },
         onLongClick = onLongClick,
     )
@@ -122,7 +122,7 @@ fun ArticleItem(
     timeString: String? = null,
     imgData: Any? = null,
     isStarred: Boolean = false,
-    isUnread: Boolean = false,
+    isRead: Boolean = false,
     onClick: () -> Unit = {},
     onLongClick: (() -> Unit)? = null,
 ) {
@@ -145,11 +145,11 @@ fun ArticleItem(
                         FlowArticleReadIndicatorPreference.None -> 1f
 
                         FlowArticleReadIndicatorPreference.AllRead -> {
-                            if (isUnread) 1f else 0.5f
+                            if (isRead) 0.5f else 1f
                         }
 
                         FlowArticleReadIndicatorPreference.ExcludingStarred -> {
-                            if (isUnread || isStarred) 1f else 0.5f
+                            if (!isRead || isStarred) 1f else 0.5f
                         }
                     }
                 )
@@ -310,7 +310,7 @@ private const val SwipeActionDelay = 300L
 @Composable
 fun SwipeableArticleItem(
     articleWithFeed: ArticleWithFeed,
-    isUnread: Boolean = articleWithFeed.article.isUnread,
+    isRead: Boolean = articleWithFeed.article.isRead,
     articleListTonalElevation: Int = 0,
     onClick: (ArticleWithFeed) -> Unit = {},
     isSwipeEnabled: () -> Boolean = { false },
@@ -334,7 +334,7 @@ fun SwipeableArticleItem(
 
     SwipeActionBox(
         articleWithFeed = articleWithFeed,
-        isRead = !isUnread,
+        isRead = isRead,
         isStarred = articleWithFeed.article.isStarred,
         onToggleStarred = onToggleStarred,
         onToggleRead = onToggleRead,
@@ -360,7 +360,7 @@ fun SwipeableArticleItem(
         ) {
             ArticleItem(
                 articleWithFeed = articleWithFeed,
-                isUnread = isUnread,
+                isRead = isRead,
                 onClick = onClick,
                 onLongClick = onLongClick,
             )
@@ -375,7 +375,7 @@ fun SwipeableArticleItem(
                         ArticleItemMenuContent(
                             articleWithFeed = articleWithFeed,
                             isStarred = isStarred,
-                            isRead = !isUnread,
+                            isRead = isRead,
                             onToggleStarred = onToggleStarred,
                             onToggleRead = onToggleRead,
                             onMarkAboveAsRead = onMarkAboveAsRead,

--- a/app/src/main/java/me/ash/reader/ui/page/home/flow/ArticleList.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/flow/ArticleList.kt
@@ -44,7 +44,7 @@ fun LazyListScope.ArticleList(
                     val article = item.articleWithFeed.article
                     SwipeableArticleItem(
                         articleWithFeed = item.articleWithFeed,
-                        isUnread = diffMap[article.id]?.isUnread ?: article.isUnread,
+                        isRead = diffMap[article.id]?.isRead ?: article.isRead,
                         articleListTonalElevation = articleListTonalElevation,
                         onClick = { onClick(it, index) },
                         isSwipeEnabled = isSwipeEnabled,
@@ -78,7 +78,7 @@ fun LazyListScope.ArticleList(
                         val article = item.articleWithFeed.article
                         SwipeableArticleItem(
                             articleWithFeed = item.articleWithFeed,
-                            isUnread = diffMap[article.id]?.isUnread ?: article.isUnread,
+                            isRead = diffMap[article.id]?.isRead ?: article.isRead,
                             articleListTonalElevation = articleListTonalElevation,
                             onClick = { onClick(it, index) },
                             isSwipeEnabled = isSwipeEnabled,

--- a/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
@@ -487,7 +487,7 @@ fun FlowPage(
                             feedId = filterUiState.feed?.id,
                             articleId = null,
                             conditions = it,
-                            isUnread = false,
+                            markRead = true,
                         )
                     }
                 }
@@ -546,7 +546,7 @@ fun FlowPage(
                                 if (items.isNotEmpty() && found) {
                                     viewModel.diffMapHolder.updateDiff(
                                         articleWithFeed = items.toTypedArray(),
-                                        isUnread = false,
+                                        markRead = true,
                                     )
                                 }
                             }
@@ -676,7 +676,7 @@ fun FlowPage(
                                     if (articleWithFeed.feed.isBrowser) {
                                         viewModel.diffMapHolder.updateDiff(
                                             articleWithFeed,
-                                            isUnread = false,
+                                            markRead = true,
                                         )
                                         context.openURL(
                                             articleWithFeed.article.link,

--- a/app/src/main/java/me/ash/reader/ui/page/home/reading/BottomBar.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/reading/BottomBar.kt
@@ -47,13 +47,13 @@ private val sizeSpec = spring<IntSize>(stiffness = 700f)
 @Composable
 fun BottomBar(
     isShow: Boolean,
-    isUnread: Boolean,
+    isRead: Boolean,
     isStarred: Boolean,
     isNextArticleAvailable: Boolean,
     isFullContent: Boolean,
     isBoldCharacters: Boolean,
     ttsButton: @Composable () -> Unit,
-    onUnread: (isUnread: Boolean) -> Unit = {},
+    onRead: (markRead: Boolean) -> Unit = {},
     onStarred: (isStarred: Boolean) -> Unit = {},
     onNextArticle: () -> Unit = {},
     onFullContent: (isFullContent: Boolean) -> Unit = {},
@@ -98,20 +98,20 @@ fun BottomBar(
                         CanBeDisabledIconButton(
                             modifier = Modifier.size(40.dp),
                             disabled = false,
-                            imageVector = if (isUnread) {
-                                Icons.Filled.FiberManualRecord
-                            } else {
+                            imageVector = if (isRead) {
                                 Icons.Outlined.FiberManualRecord
-                            },
-                            contentDescription = stringResource(if (isUnread) R.string.mark_as_read else R.string.mark_as_unread),
-                            tint = if (isUnread) {
-                                MaterialTheme.colorScheme.onSecondaryContainer
                             } else {
+                                Icons.Filled.FiberManualRecord
+                            },
+                            contentDescription = stringResource(if (isRead) R.string.mark_as_unread else R.string.mark_as_read),
+                            tint = if (isRead) {
                                 MaterialTheme.colorScheme.outline
+                            } else {
+                                MaterialTheme.colorScheme.onSecondaryContainer
                             },
                         ) {
                             view.performHapticFeedback(HapticFeedbackConstants.KEYBOARD_TAP)
-                            onUnread(!isUnread)
+                            onRead(!isRead)
                         }
                         CanBeDisabledIconButton(
                             modifier = Modifier.size(40.dp),

--- a/app/src/main/java/me/ash/reader/ui/page/home/reading/ReadingPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/reading/ReadingPage.kt
@@ -281,14 +281,14 @@ fun ReadingPage(
                 if (readerState.articleId != null) {
                     BottomBar(
                         isShow = isShowToolBar,
-                        isUnread = readingUiState.isUnread,
+                        isRead = readingUiState.isRead,
                         isStarred = readingUiState.isStarred,
                         isNextArticleAvailable = isNextArticleAvailable,
                         isFullContent =
                             readerState.content is ReaderState.FullContent ||
                                 readerState.content is ReaderState.Error,
                         isBoldCharacters = boldCharacters.value,
-                        onUnread = { viewModel.updateReadStatus(it) },
+                        onRead = { viewModel.updateReadStatus(it) },
                         onStarred = { viewModel.updateStarredStatus(it) },
                         onNextArticle = {
                             readerState.nextArticle?.let {

--- a/app/src/main/java/me/ash/reader/ui/page/settings/color/flow/FlowPagePreview.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/color/flow/FlowPagePreview.kt
@@ -108,7 +108,7 @@ fun FlowPagePreview(
             timeString = article.dateString,
             imgData = R.drawable.animation,
             isStarred = article.isStarred,
-            isUnread = article.isUnread,
+            isRead = article.isRead,
             onClick = {},
             onLongClick = null
         )

--- a/app/src/test/java/me/ash/reader/domain/data/ReadStateDiffApplierTest.kt
+++ b/app/src/test/java/me/ash/reader/domain/data/ReadStateDiffApplierTest.kt
@@ -8,8 +8,8 @@ class ReadStateDiffApplierTest {
     fun buildsReadAndUnreadBatchesFromDiffs() {
         val diffs =
             mapOf(
-                "mark-read" to Diff(isUnread = false, articleId = "mark-read", feedId = "feed"),
-                "mark-unread" to Diff(isUnread = true, articleId = "mark-unread", feedId = "feed"),
+                "mark-read" to Diff(isRead = true, articleId = "mark-read", feedId = "feed"),
+                "mark-unread" to Diff(isRead = false, articleId = "mark-unread", feedId = "feed"),
             )
 
         val batch = ReadStateDiffApplier.toBatch(diffs)
@@ -20,8 +20,8 @@ class ReadStateDiffApplierTest {
 
     @Test
     fun removesOnlyMatchingCommittedDiffs() {
-        val committedReadDiff = Diff(isUnread = false, articleId = "article", feedId = "feed")
-        val newerUnreadDiff = Diff(isUnread = true, articleId = "article", feedId = "feed")
+        val committedReadDiff = Diff(isRead = true, articleId = "article", feedId = "feed")
+        val newerUnreadDiff = Diff(isRead = false, articleId = "article", feedId = "feed")
         val currentDiffs = mutableMapOf("article" to newerUnreadDiff)
 
         ReadStateDiffApplier.removeMatchingDiffs(

--- a/app/src/test/java/me/ash/reader/ui/page/adaptive/ReadingUiStateTest.kt
+++ b/app/src/test/java/me/ash/reader/ui/page/adaptive/ReadingUiStateTest.kt
@@ -10,23 +10,23 @@ import org.junit.Test
 
 class ReadingUiStateTest {
     @Test
-    fun withUnreadState_marksTheStoredArticleSnapshotAsRead() {
-        val state = ReadingUiState(articleWithFeed = unreadArticle(), isUnread = true)
+    fun withReadState_marksTheStoredArticleSnapshotAsRead() {
+        val state = ReadingUiState(articleWithFeed = unreadArticle(), isRead = false)
 
-        val updated = state.withUnreadState(isUnread = false)
+        val updated = state.withReadState(isRead = true)
 
-        assertFalse(updated.articleWithFeed!!.article.isUnread)
-        assertFalse(updated.isUnread)
+        assertTrue(updated.articleWithFeed!!.article.isRead)
+        assertTrue(updated.isRead)
     }
 
     @Test
-    fun withUnreadState_marksTheStoredArticleSnapshotAsUnread() {
-        val state = ReadingUiState(articleWithFeed = readArticle(), isUnread = false)
+    fun withReadState_marksTheStoredArticleSnapshotAsUnread() {
+        val state = ReadingUiState(articleWithFeed = readArticle(), isRead = true)
 
-        val updated = state.withUnreadState(isUnread = true)
+        val updated = state.withReadState(isRead = false)
 
-        assertTrue(updated.articleWithFeed!!.article.isUnread)
-        assertTrue(updated.isUnread)
+        assertFalse(updated.articleWithFeed!!.article.isRead)
+        assertFalse(updated.isRead)
     }
 
     private fun unreadArticle(): ArticleWithFeed =


### PR DESCRIPTION
This reduces confusing double negatives like `!isUnread`.

## Summary
- rename app-facing read state to use isRead
- rename mutation APIs to use markRead
- keep isUnread for unread filter predicates
- clarify DAO write paths with storedUnread where they still target the legacy persisted representation

## Verification
- ./gradlew :app:testGithubDebugUnitTest --tests 'me.ash.reader.domain.data.ReadStateDiffApplierTest' --tests 'me.ash.reader.ui.page.adaptive.ReadingUiStateTest'

Closes #22
Follow-up: #23