### PR TITLE
Google Reader sync orphan cleanup does repeated O(n*m) ID scans

### DIFF
--- a/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
@@ -525,13 +525,17 @@ constructor(
 
             // 8. Remove orphaned groups and feeds, after synchronizing the
             // starred/un-starred
+            val remoteGroupIds = remoteGroupsList.mapTo(mutableSetOf()) { it.id }
+            val remoteFeedIds = remoteFeedsList.mapTo(mutableSetOf()) { it.id }
             groupDao
                 .queryAll(accountId)
-                .filter { it.id !in remoteGroupsList.map { group -> group.id } }
+                .asSequence()
+                .filter { it.id !in remoteGroupIds }
                 .forEach { super.deleteGroup(it, true) }
             feedDao
                 .queryAll(accountId)
-                .filter { it.id !in remoteFeedsList.map { feed -> feed.id } }
+                .asSequence()
+                .filter { it.id !in remoteFeedIds }
                 .forEach { super.deleteFeed(it, true) }
 
             accountService.update(account.copy(updateAt = Date()))


### PR DESCRIPTION
Precompute remote group/feed IDs once before orphan cleanup so membership checks use sets instead of repeated list scans.

Closes #10