### PR TITLE
fix(accounts): distinguish server unreachable from auth errors

### DIFF
--- a/app/src/main/java/me/ash/reader/domain/service/AbstractRssRepository.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/AbstractRssRepository.kt
@@ -47,7 +47,7 @@ abstract class AbstractRssRepository(
     open val deleteSubscription: Boolean = true
     open val updateSubscription: Boolean = true
 
-    open suspend fun validCredentials(account: Account): Boolean = true
+    open suspend fun validCredentials(account: Account) {}
 
     open suspend fun clearAuthorization() {}
 

--- a/app/src/main/java/me/ash/reader/domain/service/FeverRssService.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/FeverRssService.kt
@@ -84,8 +84,9 @@ constructor(
             )
         }
 
-    override suspend fun validCredentials(account: Account): Boolean =
-        getFeverAPI().validCredentials() > 0
+    override suspend fun validCredentials(account: Account) {
+        getFeverAPI().validCredentials()
+    }
 
     override suspend fun clearAuthorization() {
         FeverAPI.clearInstance()

--- a/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
@@ -112,16 +112,14 @@ constructor(
             )
         }
 
-    override suspend fun validCredentials(account: Account): Boolean {
-        return getGoogleReaderAPI().validCredentials().also { success ->
-            if (success)
-                try {
-                    getGoogleReaderAPI().getUserInfo().userName?.let {
-                        accountService.update(account.copy(name = it))
-                    }
-                } catch (ignore: Exception) {
-                    Log.e("RLog", "get user info is failed: ", ignore)
-                }
+    override suspend fun validCredentials(account: Account) {
+        getGoogleReaderAPI().validCredentials()
+        try {
+            getGoogleReaderAPI().getUserInfo().userName?.let {
+                accountService.update(account.copy(name = it))
+            }
+        } catch (ignore: Exception) {
+            Log.e("RLog", "get user info is failed: ", ignore)
         }
     }
 

--- a/app/src/main/java/me/ash/reader/infrastructure/exception/AuthenticationException.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/exception/AuthenticationException.kt
@@ -1,0 +1,8 @@
+package me.ash.reader.infrastructure.exception
+
+class AuthenticationException : BusinessException {
+    constructor() : super()
+    constructor(message: String) : super(message)
+    constructor(message: String, cause: Throwable) : super(message, cause)
+    constructor(cause: Throwable) : super(cause)
+}

--- a/app/src/main/java/me/ash/reader/infrastructure/rss/provider/fever/FeverAPI.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/rss/provider/fever/FeverAPI.kt
@@ -21,6 +21,7 @@ class FeverAPI private constructor(
     clientCertificateAlias: String? = null,
 ) : ProviderAPI(context, clientCertificateAlias) {
 
+    @Throws(java.io.IOException::class, FeverAPIException::class)
     private suspend inline fun <reified T> postRequest(query: String?): T {
         val response = client.newCall(
             Request.Builder()
@@ -38,12 +39,14 @@ class FeverAPI private constructor(
             .executeAsync()
 
         when (response.code) {
-            401 -> throw FeverAPIException("Unauthorized")
-            !in 200..299 -> throw FeverAPIException("Forbidden")
+            401 -> throw FeverAPIException("Invalid credentials")
+            !in 200..299 -> throw FeverAPIException("Server error (${response.code})")
         }
         return try {
             val resp = response.body.string()
             toDTO<T>(resp)
+        } catch (e: java.io.IOException) {
+            throw e
         } catch (e: Exception) {
             throw FeverAPIException("Unable to parse response", e)
         }
@@ -52,7 +55,7 @@ class FeverAPI private constructor(
     private fun checkAuth(authMap: Map<String, Any>): Int = checkAuth(authMap["auth"] as Int?)
 
     private fun checkAuth(auth: Int?): Int =
-        auth?.takeIf { it > 0 } ?: throw FeverAPIException("Unauthorized")
+        auth?.takeIf { it > 0 } ?: throw FeverAPIException("Invalid credentials")
 
     @Throws
     suspend fun validCredentials(): Int = checkAuth(postRequest<FeverDTO.Common>(null).auth)

--- a/app/src/main/java/me/ash/reader/infrastructure/rss/provider/fever/FeverAPI.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/rss/provider/fever/FeverAPI.kt
@@ -1,6 +1,7 @@
 package me.ash.reader.infrastructure.rss.provider.fever
 
 import android.content.Context
+import me.ash.reader.infrastructure.exception.AuthenticationException
 import me.ash.reader.infrastructure.exception.FeverAPIException
 import me.ash.reader.infrastructure.net.RetryConfig
 import me.ash.reader.infrastructure.net.withRetries
@@ -39,7 +40,7 @@ class FeverAPI private constructor(
             .executeAsync()
 
         when (response.code) {
-            401 -> throw FeverAPIException("Invalid credentials")
+            401 -> throw AuthenticationException("Invalid credentials")
             !in 200..299 -> throw FeverAPIException("Server error (${response.code})")
         }
         return try {
@@ -55,10 +56,12 @@ class FeverAPI private constructor(
     private fun checkAuth(authMap: Map<String, Any>): Int = checkAuth(authMap["auth"] as Int?)
 
     private fun checkAuth(auth: Int?): Int =
-        auth?.takeIf { it > 0 } ?: throw FeverAPIException("Invalid credentials")
+        auth?.takeIf { it > 0 } ?: throw AuthenticationException("Invalid credentials")
 
     @Throws
-    suspend fun validCredentials(): Int = checkAuth(postRequest<FeverDTO.Common>(null).auth)
+    suspend fun validCredentials() {
+        checkAuth(postRequest<FeverDTO.Common>(null).auth)
+    }
 
     suspend fun getApiVersion(): Long =
         postRequest<Map<String, Any>>(null)["api_version"] as Long?

--- a/app/src/main/java/me/ash/reader/infrastructure/rss/provider/greader/GoogleReaderAPI.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/rss/provider/greader/GoogleReaderAPI.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.update
 import me.ash.reader.domain.data.SyncLogger
 import me.ash.reader.infrastructure.di.USER_AGENT_STRING
+import me.ash.reader.infrastructure.exception.AuthenticationException
 import me.ash.reader.infrastructure.exception.GoogleReaderAPIException
 import me.ash.reader.infrastructure.exception.RetryException
 import me.ash.reader.infrastructure.net.ApiResult
@@ -69,14 +70,13 @@ private constructor(
             authDataStateFlow.value = value
         }
 
-    suspend fun validCredentials(): Boolean {
-        return when (val result = reAuthenticate()) {
+    suspend fun validCredentials() {
+        when (val result = reAuthenticate()) {
             is ApiResult.Success -> {
                 authData = result.data
-                true
             }
             is ApiResult.NetworkError -> throw result.exception
-            is ApiResult.BizError -> throw result.exception
+            is ApiResult.BizError -> throw AuthenticationException(result.exception.message ?: "Authentication failed")
             is ApiResult.UnknownError -> throw result.throwable
         }
     }

--- a/app/src/main/java/me/ash/reader/infrastructure/rss/provider/greader/GoogleReaderAPI.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/rss/provider/greader/GoogleReaderAPI.kt
@@ -70,8 +70,15 @@ private constructor(
         }
 
     suspend fun validCredentials(): Boolean {
-        val result = reAuthenticate().onSuccess { authData = it }
-        return result.isSuccess
+        return when (val result = reAuthenticate()) {
+            is ApiResult.Success -> {
+                authData = result.data
+                true
+            }
+            is ApiResult.NetworkError -> throw result.exception
+            is ApiResult.BizError -> throw result.exception
+            is ApiResult.UnknownError -> throw result.throwable
+        }
     }
 
     suspend fun refreshCredentialsIfNeeded() {
@@ -109,8 +116,8 @@ private constructor(
 
         val clBody = clResponse.body.string()
         when (clResponse.code) {
-            400 -> return ApiResult.BizError(GoogleReaderAPIException("BadRequest for CL Token"))
-            401 -> return ApiResult.BizError(GoogleReaderAPIException("Unauthorized for CL Token"))
+            400 -> return ApiResult.BizError(GoogleReaderAPIException("Bad request"))
+            401 -> return ApiResult.BizError(GoogleReaderAPIException("Invalid credentials"))
             !in 200..299 -> {
                 return ApiResult.BizError(GoogleReaderAPIException(clBody))
             }

--- a/app/src/main/java/me/ash/reader/ui/page/settings/accounts/AccountViewModel.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/accounts/AccountViewModel.kt
@@ -1,8 +1,10 @@
 package me.ash.reader.ui.page.settings.accounts
 
+import android.content.Context
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import dagger.hilt.android.lifecycle.HiltViewModel
+import dagger.hilt.android.qualifiers.ApplicationContext
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
@@ -14,6 +16,7 @@ import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
+import me.ash.reader.R
 import me.ash.reader.domain.model.account.Account
 import me.ash.reader.domain.service.AccountService
 import me.ash.reader.domain.service.OpmlService
@@ -22,10 +25,12 @@ import me.ash.reader.infrastructure.di.ApplicationScope
 import me.ash.reader.infrastructure.di.DefaultDispatcher
 import me.ash.reader.infrastructure.di.IODispatcher
 import me.ash.reader.infrastructure.di.MainDispatcher
+import java.io.IOException
 import javax.inject.Inject
 
 @HiltViewModel
 class AccountViewModel @Inject constructor(
+    @ApplicationContext private val context: Context,
     private val accountService: AccountService,
     private val rssService: RssService,
     private val opmlService: OpmlService,
@@ -110,7 +115,12 @@ class AccountViewModel @Inject constructor(
                         callback(addAccount, null)
                     }
                 } else {
-                    throw Exception("Unauthorized")
+                    throw Exception(context.getString(R.string.unauthorized))
+                }
+            } catch (e: IOException) {
+                accountService.delete(addAccount.id!!)
+                withContext(mainDispatcher) {
+                    callback(null, Exception(context.getString(R.string.server_unreachable)))
                 }
             } catch (e: Exception) {
                 accountService.delete(addAccount.id!!)

--- a/app/src/main/java/me/ash/reader/ui/page/settings/accounts/AccountViewModel.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/accounts/AccountViewModel.kt
@@ -25,6 +25,7 @@ import me.ash.reader.infrastructure.di.ApplicationScope
 import me.ash.reader.infrastructure.di.DefaultDispatcher
 import me.ash.reader.infrastructure.di.IODispatcher
 import me.ash.reader.infrastructure.di.MainDispatcher
+import me.ash.reader.infrastructure.exception.AuthenticationException
 import java.io.IOException
 import javax.inject.Inject
 
@@ -109,18 +110,20 @@ class AccountViewModel @Inject constructor(
             val addAccount = accountService.addAccount(account)
             try {
                 val rssService = rssService.get(addAccount.type.id)
-                if (rssService.validCredentials(account)) {
-                    rssService.doSyncOneTime()
-                    withContext(mainDispatcher) {
-                        callback(addAccount, null)
-                    }
-                } else {
-                    throw Exception(context.getString(R.string.unauthorized))
+                rssService.validCredentials(account)
+                rssService.doSyncOneTime()
+                withContext(mainDispatcher) {
+                    callback(addAccount, null)
                 }
             } catch (e: IOException) {
                 accountService.delete(addAccount.id!!)
                 withContext(mainDispatcher) {
                     callback(null, Exception(context.getString(R.string.server_unreachable)))
+                }
+            } catch (e: AuthenticationException) {
+                accountService.delete(addAccount.id!!)
+                withContext(mainDispatcher) {
+                    callback(null, Exception(context.getString(R.string.unauthorized)))
                 }
             } catch (e: Exception) {
                 accountService.delete(addAccount.id!!)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -382,4 +382,6 @@
     <string name="parse_full_content_desc">Fetch full articles from webpages</string>
     <string name="enable">Enable</string>
     <string name="disable">Disable</string>
+    <string name="server_unreachable">Server unreachable. Check your network connection and server URL.</string>
+    <string name="unauthorized">Invalid credentials</string>
 </resources>


### PR DESCRIPTION
## Summary
- Fix misleading "Unauthorized" error when FreshRSS/Fever server is unavailable
- Properly propagate `IOException` for network errors
- Show user-friendly error messages

## Changes
- **AccountViewModel.kt**: Catch `IOException` separately to show "Server unreachable" message
- **GoogleReaderAPI.kt**: Propagate network errors instead of masking them; improved error messages
- **FeverAPI.kt**: Propagate `IOException` on network errors; improved error messages  
- **strings.xml**: Added `server_unreachable` and `unauthorized` string resources

## Test plan
1. Disable network or use invalid server URL when adding FreshRSS account
2. Verify error shows "Server unreachable" instead of "Unauthorized"
3. Use valid server but wrong credentials
4. Verify error shows "Invalid credentials"

Closes #1

Made with [Cursor](https://cursor.com)