### PR TITLE
refactor(read-state): rename persisted isUnread fields to isRead

### DIFF
--- a/app/src/main/java/me/ash/reader/domain/data/DiffMapHolder.kt
+++ b/app/src/main/java/me/ash/reader/domain/data/DiffMapHolder.kt
@@ -324,7 +324,7 @@ class DiffMapHolder @Inject constructor(
             articleId = diff.articleId,
             accountId = accountId,
             feedId = diff.feedId,
-            isUnread = !diff.isRead,
+            isRead = diff.isRead,
         )
     }
 

--- a/app/src/main/java/me/ash/reader/domain/model/article/Article.kt
+++ b/app/src/main/java/me/ash/reader/domain/model/article/Article.kt
@@ -41,8 +41,8 @@ data class Article(
     var feedId: String,
     @field:ColumnInfo(index = true)
     var accountId: Int,
-    @field:ColumnInfo
-    var isUnread: Boolean = true,
+    @field:ColumnInfo(name = "isUnread")
+    var isRead: Boolean = false,
     @field:ColumnInfo
     var isStarred: Boolean = false,
     @field:ColumnInfo
@@ -53,10 +53,4 @@ data class Article(
 
     @Ignore
     var dateString: String? = null
-
-    var isRead: Boolean
-        get() = !isUnread
-        set(value) {
-            isUnread = !value
-        }
 }

--- a/app/src/main/java/me/ash/reader/domain/model/article/ArticleMeta.kt
+++ b/app/src/main/java/me/ash/reader/domain/model/article/ArticleMeta.kt
@@ -10,14 +10,8 @@ import androidx.room.PrimaryKey
 data class ArticleMeta(
     @field:PrimaryKey
     var id: String,
-    @field:ColumnInfo
-    var isUnread: Boolean = true,
+    @field:ColumnInfo(name = "isUnread")
+    var isRead: Boolean = false,
     @field:ColumnInfo
     var isStarred: Boolean = false,
-) {
-    var isRead: Boolean
-        get() = !isUnread
-        set(value) {
-            isUnread = !value
-        }
-}
+)

--- a/app/src/main/java/me/ash/reader/domain/model/article/PendingReadStateOp.kt
+++ b/app/src/main/java/me/ash/reader/domain/model/article/PendingReadStateOp.kt
@@ -17,11 +17,8 @@ data class PendingReadStateOp(
     val accountId: Int,
     @ColumnInfo
     val feedId: String,
-    @ColumnInfo
-    val isUnread: Boolean,
+    @ColumnInfo(name = "isUnread")
+    val isRead: Boolean,
     @ColumnInfo
     val updatedAt: Date = Date(),
-) {
-    val isRead: Boolean
-        get() = !isUnread
-}
+)

--- a/app/src/main/java/me/ash/reader/domain/repository/ArticleDao.kt
+++ b/app/src/main/java/me/ash/reader/domain/repository/ArticleDao.kt
@@ -36,7 +36,7 @@ interface ArticleDao {
 
     @Query(
         """
-        UPDATE article SET isUnread = :storedUnread 
+        UPDATE article SET isUnread = NOT :isRead 
         WHERE accountId = :accountId
         AND id in (:ids)
         """
@@ -44,7 +44,7 @@ interface ArticleDao {
     fun markAsReadByIdSet(
         accountId: Int,
         ids: Set<String>,
-        storedUnread: Boolean,
+        isRead: Boolean,
     ): Int
 
     @Transaction
@@ -92,7 +92,7 @@ interface ArticleDao {
         AND feedId IN (
             SELECT id FROM feed WHERE groupId = :groupId
         )
-        AND isUnread = :isUnread
+        AND isUnread = NOT :isRead
         AND (
             title LIKE '%' || :text || '%'
             OR shortDescription LIKE '%' || :text || '%'
@@ -107,7 +107,7 @@ interface ArticleDao {
         accountId: Int,
         text: String,
         groupId: String,
-        isUnread: Boolean,
+        isRead: Boolean,
         sortAscending: Boolean = false
     ): PagingSource<Int, ArticleWithFeed>
 
@@ -166,7 +166,7 @@ interface ArticleDao {
         SELECT * FROM article
         WHERE accountId = :accountId 
         AND feedId = :feedId
-        AND isUnread = :isUnread
+        AND isUnread = NOT :isRead
         AND (
             title LIKE '%' || :text || '%'
             OR shortDescription LIKE '%' || :text || '%'
@@ -181,7 +181,7 @@ interface ArticleDao {
         accountId: Int,
         text: String,
         feedId: String,
-        isUnread: Boolean,
+        isRead: Boolean,
         sortAscending: Boolean = false
     ): PagingSource<Int, ArticleWithFeed>
 
@@ -235,7 +235,7 @@ interface ArticleDao {
         """
         SELECT * FROM article
         WHERE accountId = :accountId 
-        AND isUnread = :isUnread
+        AND isUnread = NOT :isRead
         AND (
             title LIKE '%' || :text || '%'
             OR shortDescription LIKE '%' || :text || '%'
@@ -247,7 +247,7 @@ interface ArticleDao {
         """
     )
     fun searchArticleWhenIsUnread(
-        accountId: Int, text: String, isUnread: Boolean, sortAscending: Boolean = false
+        accountId: Int, text: String, isRead: Boolean, sortAscending: Boolean = false
     ): PagingSource<Int, ArticleWithFeed>
 
     @Transaction
@@ -321,59 +321,59 @@ interface ArticleDao {
     @Transaction
     @Query(
         """
-        UPDATE article SET isUnread = :storedUnread 
+        UPDATE article SET isUnread = NOT :isRead 
         WHERE accountId = :accountId
         AND date < :before
-        AND isUnread != :storedUnread
+        AND isUnread != NOT :isRead
         """
     )
     suspend fun markAllAsRead(
         accountId: Int,
-        storedUnread: Boolean,
+        isRead: Boolean,
         before: Date,
     )
 
     @Transaction
     @Query(
         """
-        UPDATE article SET isUnread = :storedUnread 
+        UPDATE article SET isUnread = NOT :isRead 
         WHERE feedId IN (
             SELECT id FROM feed 
             WHERE groupId = :groupId
         )
         AND accountId = :accountId
-        AND isUnread != :storedUnread
+        AND isUnread != NOT :isRead
         AND date < :before
         """
     )
     suspend fun markAllAsReadByGroupId(
         accountId: Int,
         groupId: String,
-        storedUnread: Boolean,
+        isRead: Boolean,
         before: Date,
     )
 
     @Transaction
     @Query(
         """
-        UPDATE article SET isUnread = :storedUnread 
+        UPDATE article SET isUnread = NOT :isRead 
         WHERE feedId = :feedId
         AND accountId = :accountId
-        AND isUnread != :storedUnread
+        AND isUnread != NOT :isRead
         AND date < :before
         """
     )
     suspend fun markAllAsReadByFeedId(
         accountId: Int,
         feedId: String,
-        storedUnread: Boolean,
+        isRead: Boolean,
         before: Date,
     )
 
     @Transaction
     @Query(
         """
-        UPDATE article SET isUnread = :storedUnread 
+        UPDATE article SET isUnread = NOT :isRead 
         WHERE id = :articleId
         AND accountId = :accountId
         """
@@ -381,7 +381,7 @@ interface ArticleDao {
     suspend fun markAsReadByArticleId(
         accountId: Int,
         articleId: String,
-        storedUnread: Boolean,
+        isRead: Boolean,
     )
 
     @Query(
@@ -436,14 +436,14 @@ interface ArticleDao {
         """
         SELECT feedId, COUNT(*) AS important
         FROM article
-        WHERE isUnread = :isUnread
+        WHERE isUnread = NOT :isRead
         AND accountId = :accountId
         GROUP BY feedId
         """
     )
     fun queryImportantCountWhenIsUnread(
         accountId: Int,
-        isUnread: Boolean,
+        isRead: Boolean,
     ): Flow<Map<@MapColumn("feedId") String, @MapColumn("important") Int>>
 
     @Transaction
@@ -507,7 +507,7 @@ interface ArticleDao {
     @Query(
         """
         SELECT * FROM article 
-        WHERE isUnread = :isUnread 
+        WHERE isUnread = NOT :isRead 
         AND accountId = :accountId
         ORDER BY
             CASE WHEN :sortAscending = 1 THEN date END ASC,
@@ -515,7 +515,7 @@ interface ArticleDao {
         """
     )
     fun queryArticleWithFeedWhenIsUnread(
-        accountId: Int, isUnread: Boolean, sortAscending: Boolean = false
+        accountId: Int, isRead: Boolean, sortAscending: Boolean = false
     ): PagingSource<Int, ArticleWithFeed>
 
     @Transaction
@@ -572,7 +572,7 @@ interface ArticleDao {
         LEFT JOIN feed AS b ON b.id = a.feedId
         LEFT JOIN `group` AS c ON c.id = b.groupId
         WHERE c.id = :groupId
-        AND a.isUnread = :isUnread
+        AND a.isUnread = NOT :isRead
         AND a.accountId = :accountId
         ORDER BY
             CASE WHEN :sortAscending = 1 THEN a.date END ASC,
@@ -580,7 +580,7 @@ interface ArticleDao {
         """
     )
     fun queryArticleWithFeedByGroupIdWhenIsUnread(
-        accountId: Int, groupId: String, isUnread: Boolean, sortAscending: Boolean = false
+        accountId: Int, groupId: String, isRead: Boolean, sortAscending: Boolean = false
     ): PagingSource<Int, ArticleWithFeed>
 
     @Transaction
@@ -619,7 +619,7 @@ interface ArticleDao {
         """
         SELECT * FROM article 
         WHERE feedId = :feedId 
-        AND isUnread = :isUnread
+        AND isUnread = NOT :isRead
         AND accountId = :accountId
         ORDER BY
             CASE WHEN :sortAscending = 1 THEN date END ASC,
@@ -627,7 +627,7 @@ interface ArticleDao {
         """
     )
     fun queryArticleWithFeedByFeedIdWhenIsUnread(
-        accountId: Int, feedId: String, isUnread: Boolean, sortAscending: Boolean = false
+        accountId: Int, feedId: String, isRead: Boolean, sortAscending: Boolean = false
     ): PagingSource<Int, ArticleWithFeed>
 
 
@@ -704,14 +704,14 @@ interface ArticleDao {
         """
         SELECT id, isUnread, isStarred FROM article
         WHERE accountId = :accountId
-        AND isUnread = :isUnread
+        AND isUnread = NOT :isRead
         ORDER BY
             CASE WHEN :sortAscending = 1 THEN date END ASC,
             CASE WHEN :sortAscending = 0 THEN date END DESC
         """
     )
     fun queryMetadataAll(
-        accountId: Int, isUnread: Boolean, sortAscending: Boolean = false
+        accountId: Int, isRead: Boolean, sortAscending: Boolean = false
     ): List<ArticleMeta>
 
     @Transaction
@@ -734,7 +734,7 @@ interface ArticleDao {
         """
         SELECT id, isUnread, isStarred FROM article
         WHERE accountId = :accountId
-        AND isUnread = :isUnread
+        AND isUnread = NOT :isRead
         AND date < :before
         ORDER BY
             CASE WHEN :sortAscending = 1 THEN date END ASC,
@@ -742,7 +742,7 @@ interface ArticleDao {
         """
     )
     fun queryMetadataAll(
-        accountId: Int, isUnread: Boolean, before: Date, sortAscending: Boolean = false
+        accountId: Int, isRead: Boolean, before: Date, sortAscending: Boolean = false
     ): List<ArticleMeta>
 
     @Transaction
@@ -751,14 +751,14 @@ interface ArticleDao {
         SELECT id, isUnread, isStarred FROM article
         WHERE accountId = :accountId
         AND feedId = :feedId
-        AND isUnread = :isUnread
+        AND isUnread = NOT :isRead
         ORDER BY
             CASE WHEN :sortAscending = 1 THEN date END ASC,
             CASE WHEN :sortAscending = 0 THEN date END DESC
         """
     )
     fun queryMetadataByFeedId(
-        accountId: Int, feedId: String, isUnread: Boolean, sortAscending: Boolean = false
+        accountId: Int, feedId: String, isRead: Boolean, sortAscending: Boolean = false
     ): List<ArticleMeta>
 
     @Transaction
@@ -767,7 +767,7 @@ interface ArticleDao {
         SELECT id, isUnread, isStarred FROM article
         WHERE accountId = :accountId
         AND feedId = :feedId
-        AND isUnread = :isUnread
+        AND isUnread = NOT :isRead
         AND date < :before
         ORDER BY
             CASE WHEN :sortAscending = 1 THEN date END ASC,
@@ -777,7 +777,7 @@ interface ArticleDao {
     fun queryMetadataByFeedId(
         accountId: Int,
         feedId: String,
-        isUnread: Boolean,
+        isRead: Boolean,
         before: Date,
         sortAscending: Boolean = false
     ): List<ArticleMeta>
@@ -791,14 +791,14 @@ interface ArticleDao {
         LEFT JOIN `group` AS c ON c.id = b.groupId
         WHERE c.id = :groupId
         AND a.accountId = :accountId
-        AND a.isUnread = :isUnread
+        AND a.isUnread = NOT :isRead
         ORDER BY
             CASE WHEN :sortAscending = 1 THEN a.date END ASC,
             CASE WHEN :sortAscending = 0 THEN a.date END DESC
         """
     )
     fun queryMetadataByGroupIdWhenIsUnread(
-        accountId: Int, groupId: String, isUnread: Boolean, sortAscending: Boolean = false
+        accountId: Int, groupId: String, isRead: Boolean, sortAscending: Boolean = false
     ): List<ArticleMeta>
 
     @Transaction
@@ -810,7 +810,7 @@ interface ArticleDao {
         LEFT JOIN `group` AS c ON c.id = b.groupId
         WHERE c.id = :groupId
         AND a.accountId = :accountId
-        AND a.isUnread = :isUnread
+        AND a.isUnread = NOT :isRead
         AND a.date < :before
         ORDER BY
             CASE WHEN :sortAscending = 1 THEN a.date END ASC,
@@ -820,7 +820,7 @@ interface ArticleDao {
     fun queryMetadataByGroupIdWhenIsUnread(
         accountId: Int,
         groupId: String,
-        isUnread: Boolean,
+        isRead: Boolean,
         before: Date,
         sortAscending: Boolean = false
     ): List<ArticleMeta>

--- a/app/src/main/java/me/ash/reader/domain/service/AbstractRssRepository.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/AbstractRssRepository.kt
@@ -102,14 +102,13 @@ abstract class AbstractRssRepository(
         before: Date?,
         markRead: Boolean,
     ) {
-        val storedUnread = !markRead
         val accountId = accountService.getCurrentAccountId()
         when {
             groupId != null -> {
                 articleDao.markAllAsReadByGroupId(
                     accountId = accountId,
                     groupId = groupId,
-                    storedUnread = storedUnread,
+                    isRead = markRead,
                     before = before ?: Date(Long.MAX_VALUE),
                 )
             }
@@ -118,29 +117,28 @@ abstract class AbstractRssRepository(
                 articleDao.markAllAsReadByFeedId(
                     accountId = accountId,
                     feedId = feedId,
-                    storedUnread = storedUnread,
+                    isRead = markRead,
                     before = before ?: Date(Long.MAX_VALUE),
                 )
             }
 
             articleId != null -> {
-                articleDao.markAsReadByArticleId(accountId, articleId, storedUnread)
+                articleDao.markAsReadByArticleId(accountId, articleId, markRead)
             }
 
             else -> {
-                articleDao.markAllAsRead(accountId, storedUnread, before ?: Date(Long.MAX_VALUE))
+                articleDao.markAllAsRead(accountId, markRead, before ?: Date(Long.MAX_VALUE))
             }
         }
     }
 
     open suspend fun batchMarkAsRead(articleIds: Set<String>, markRead: Boolean) {
         val accountId = accountService.getCurrentAccountId()
-        val storedUnread = !markRead
         articleIds
             .takeIf { it.isNotEmpty() }
             ?.chunked(500)
             ?.forEachIndexed { index, it ->
-                articleDao.markAsReadByIdSet(accountId, it.toSet(), storedUnread)
+                articleDao.markAsReadByIdSet(accountId, it.toSet(), markRead)
             }
     }
 
@@ -245,7 +243,7 @@ abstract class AbstractRssRepository(
                         articleDao.queryArticleWithFeedByGroupIdWhenIsUnread(
                             accountId,
                             groupId,
-                            true,
+                            isRead = false,
                             sortAscending = sortAscending,
                         )
 
@@ -265,7 +263,7 @@ abstract class AbstractRssRepository(
                         articleDao.queryArticleWithFeedByFeedIdWhenIsUnread(
                             accountId,
                             feedId,
-                            true,
+                            isRead = false,
                             sortAscending = sortAscending,
                         )
 
@@ -278,7 +276,7 @@ abstract class AbstractRssRepository(
                     isUnread ->
                         articleDao.queryArticleWithFeedWhenIsUnread(
                             accountId,
-                            true,
+                            isRead = false,
                             sortAscending = sortAscending,
                         )
 
@@ -296,7 +294,7 @@ abstract class AbstractRssRepository(
         )
         return when {
             isStarred -> articleDao.queryImportantCountWhenIsStarred(accountId, true)
-            isUnread -> articleDao.queryImportantCountWhenIsUnread(accountId, true)
+            isUnread -> articleDao.queryImportantCountWhenIsUnread(accountId, isRead = false)
             else -> articleDao.queryImportantCountWhenIsAll(accountId)
         }
     }
@@ -444,7 +442,7 @@ abstract class AbstractRssRepository(
                             accountId,
                             content,
                             groupId,
-                            true,
+                            isRead = false,
                             sortAscending,
                         )
 
@@ -466,7 +464,7 @@ abstract class AbstractRssRepository(
                             accountId,
                             content,
                             feedId,
-                            true,
+                            isRead = false,
                             sortAscending,
                         )
 
@@ -480,7 +478,7 @@ abstract class AbstractRssRepository(
                         articleDao.searchArticleWhenIsUnread(
                             accountId,
                             content,
-                            true,
+                            isRead = false,
                             sortAscending,
                         )
 

--- a/app/src/main/java/me/ash/reader/domain/service/FeverRssService.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/FeverRssService.kt
@@ -245,7 +245,7 @@ constructor(
                             link = item.url ?: "",
                             feedId = accountId.spacerDollar(item.feed_id!!),
                             accountId = accountId,
-                            isUnread = (item.is_read ?: 0) <= 0,
+                            isRead = (item.is_read ?: 0) > 0,
                             isStarred = (item.is_saved ?: 0) > 0,
                             updateAt = preDate,
                         )
@@ -284,7 +284,7 @@ constructor(
                     articleDao.markAsReadByArticleId(
                         accountId = accountId,
                         articleId = meta.id,
-                        storedUnread = !shouldBeRead,
+                        isRead = shouldBeRead,
                     )
                 }
                 if (meta.isStarred != shouldBeStarred) {

--- a/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
@@ -387,7 +387,7 @@ constructor(
                     articleDao.markAsReadByIdSet(
                         accountId = accountId,
                         ids = it.toSet(),
-                        storedUnread = false,
+                        isRead = true,
                     )
                 }
             }
@@ -407,7 +407,7 @@ constructor(
                     articleDao.markAsReadByIdSet(
                         accountId = accountId,
                         ids = it.toSet(),
-                        storedUnread = true,
+                        isRead = false,
                     )
                 }
             }
@@ -569,19 +569,19 @@ constructor(
 
             val localStarredIds =
                 articleDao
-                    .queryMetadataByFeedId(accountId, feedId, isUnread = true)
+                    .queryMetadataByFeedId(accountId, feedId, isRead = false)
                     .map { it.id.remoteId }
                     .toSet()
 
             val localUnreadIds =
                 articleDao
-                    .queryMetadataByFeedId(accountId, feedId, isUnread = true)
+                    .queryMetadataByFeedId(accountId, feedId, isRead = false)
                     .map { it.id.remoteId }
                     .toSet()
 
             val localReadIds =
                 articleDao
-                    .queryMetadataByFeedId(accountId, feedId, isUnread = false)
+                    .queryMetadataByFeedId(accountId, feedId, isRead = true)
                     .map { it.id.remoteId }
                     .toSet()
 
@@ -651,7 +651,7 @@ constructor(
                         articleDao.markAsReadByIdSet(
                             accountId = accountId,
                             ids = it.toSet(),
-                            storedUnread = false,
+                            isRead = true,
                         )
                     }
             }
@@ -673,7 +673,7 @@ constructor(
                         articleDao.markAsReadByIdSet(
                             accountId = accountId,
                             ids = it.toSet(),
-                            storedUnread = true,
+                            isRead = false,
                         )
                     }
             }
@@ -773,7 +773,7 @@ constructor(
                                         it.origin?.streamId?.ofFeedStreamIdToId()!!
                                     ),
                                 accountId = accountId,
-                                isUnread = unreadIds.contains(articleId),
+                                isRead = !unreadIds.contains(articleId),
                                 isStarred = starredIds.contains(articleId),
                                 updateAt =
                                     updated?.let { Date(updated * 1000L) }
@@ -819,7 +819,6 @@ constructor(
         before: Date?,
         markRead: Boolean,
     ) {
-        val storedUnread = !markRead
         val accountId = accountService.getCurrentAccountId()
         val googleReaderAPI = getGoogleReaderAPI()
         val markList: List<String> =
@@ -829,13 +828,13 @@ constructor(
                             articleDao.queryMetadataByGroupIdWhenIsUnread(
                                 accountId,
                                 groupId,
-                                isUnread = !storedUnread,
+                                isRead = !markRead,
                             )
                         } else {
                             articleDao.queryMetadataByGroupIdWhenIsUnread(
                                 accountId,
                                 groupId,
-                                isUnread = !storedUnread,
+                                isRead = !markRead,
                                 before = before,
                             )
                         }
@@ -844,9 +843,9 @@ constructor(
 
                 feedId != null -> {
                     if (before == null) {
-                            articleDao.queryMetadataByFeedId(accountId, feedId, isUnread = !storedUnread)
+                            articleDao.queryMetadataByFeedId(accountId, feedId, isRead = !markRead)
                         } else {
-                            articleDao.queryMetadataByFeedId(accountId, feedId, isUnread = !storedUnread, before = before)
+                            articleDao.queryMetadataByFeedId(accountId, feedId, isRead = !markRead, before = before)
                         }
                         .map { it.id.dollarLast() }
                 }
@@ -857,9 +856,9 @@ constructor(
 
                 else -> {
                     if (before == null) {
-                            articleDao.queryMetadataAll(accountId, isUnread = !storedUnread)
+                            articleDao.queryMetadataAll(accountId, isRead = !markRead)
                         } else {
-                            articleDao.queryMetadataAll(accountId, isUnread = !storedUnread, before = before)
+                            articleDao.queryMetadataAll(accountId, isRead = !markRead, before = before)
                         }
                         .map { it.id.dollarLast() }
                 }

--- a/app/src/main/java/me/ash/reader/ui/page/adaptive/ArticleListReaderViewModel.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/adaptive/ArticleListReaderViewModel.kt
@@ -457,7 +457,7 @@ data class ReadingUiState(
     fun withReadState(isRead: Boolean): ReadingUiState =
         copy(
             articleWithFeed =
-                articleWithFeed?.copy(article = articleWithFeed.article.copy(isUnread = !isRead)),
+                articleWithFeed?.copy(article = articleWithFeed.article.copy(isRead = isRead)),
             isRead = isRead,
         )
 }

--- a/app/src/test/java/me/ash/reader/ui/page/adaptive/ReadingUiStateTest.kt
+++ b/app/src/test/java/me/ash/reader/ui/page/adaptive/ReadingUiStateTest.kt
@@ -41,13 +41,13 @@ class ReadingUiStateTest {
                     link = "https://example.com/article",
                     feedId = "feed",
                     accountId = 1,
-                    isUnread = true,
+                    isRead = false,
                 ),
             feed = sampleFeed(),
         )
 
     private fun readArticle(): ArticleWithFeed =
-        unreadArticle().run { copy(article = article.copy(isUnread = false)) }
+        unreadArticle().run { copy(article = article.copy(isRead = true)) }
 
     private fun sampleFeed(): Feed =
         Feed(


### PR DESCRIPTION
## Summary
- Renamed Room model fields from `isUnread` to `isRead` (`Article`, `ArticleMeta`, `PendingReadStateOp`)
- Used `@ColumnInfo(name = "isUnread")` to map to existing database column, avoiding migrations
- Updated DAO parameters and inverted SQL logic to maintain correct behavior
- Updated all callers in services, repositories, and tests

## Test plan
- [x] Build compiles successfully (`./gradlew assembleDebug`)
- [x] Unit tests pass (`./gradlew testFdroidDebugUnitTest`)
- [ ] Manual testing: verify read/unread state behaves correctly

Closes #23

Made with [Cursor](https://cursor.com)