### PR TITLE
fix(crash): show toast for network errors instead of crash report

### DIFF
--- a/app/src/main/java/me/ash/reader/infrastructure/android/CrashHandler.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/android/CrashHandler.kt
@@ -2,10 +2,12 @@ package me.ash.reader.infrastructure.android
 
 import android.content.Context
 import android.content.Intent
+import android.os.Handler
 import android.os.Looper
 import android.util.Log
-import me.ash.reader.infrastructure.exception.BusinessException
+import me.ash.reader.R
 import me.ash.reader.ui.ext.showToastLong
+import java.io.IOException
 import java.lang.Thread.UncaughtExceptionHandler
 
 /**
@@ -24,21 +26,26 @@ class CrashHandler(private val context: Context) : UncaughtExceptionHandler {
         val causeMessage = getCauseMessage(p1)
         Log.e("RLog", "uncaughtException: $causeMessage", p1)
 
-        when (p1) {
-            is BusinessException -> {
-                context.startActivity(Intent(context, CrashReportActivity::class.java).apply {
-                    flags = Intent.FLAG_ACTIVITY_NEW_TASK
-                    putExtra(CrashReportActivity.ERROR_REPORT_KEY, p1.stackTraceToString())
-                })
+        val rootCause = getRootCause(p1)
+        if (rootCause is IOException) {
+            Handler(Looper.getMainLooper()).post {
+                context.showToastLong(context.getString(R.string.server_unreachable))
             }
-
-            else -> {
-                context.startActivity(Intent(context, CrashReportActivity::class.java).apply {
-                    flags = Intent.FLAG_ACTIVITY_NEW_TASK
-                    putExtra(CrashReportActivity.ERROR_REPORT_KEY, p1.stackTraceToString())
-                })
-            }
+            return
         }
+
+        context.startActivity(Intent(context, CrashReportActivity::class.java).apply {
+            flags = Intent.FLAG_ACTIVITY_NEW_TASK
+            putExtra(CrashReportActivity.ERROR_REPORT_KEY, p1.stackTraceToString())
+        })
+    }
+
+    private fun getRootCause(e: Throwable?): Throwable? {
+        var cause = e
+        while (cause?.cause != null) {
+            cause = cause.cause
+        }
+        return cause
     }
 
     private fun getCauseMessage(e: Throwable?): String? {

--- a/app/src/main/java/me/ash/reader/infrastructure/android/CrashHandler.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/android/CrashHandler.kt
@@ -2,13 +2,16 @@ package me.ash.reader.infrastructure.android
 
 import android.content.Context
 import android.content.Intent
-import android.os.Handler
 import android.os.Looper
 import android.util.Log
 import me.ash.reader.R
 import me.ash.reader.ui.ext.showToastLong
-import java.io.IOException
 import java.lang.Thread.UncaughtExceptionHandler
+import java.net.ConnectException
+import java.net.NoRouteToHostException
+import java.net.SocketException
+import java.net.SocketTimeoutException
+import java.net.UnknownHostException
 
 /**
  * The uncaught exception handler for the application.
@@ -27,10 +30,8 @@ class CrashHandler(private val context: Context) : UncaughtExceptionHandler {
         Log.e("RLog", "uncaughtException: $causeMessage", p1)
 
         val rootCause = getRootCause(p1)
-        if (rootCause is IOException) {
-            Handler(Looper.getMainLooper()).post {
-                context.showToastLong(context.getString(R.string.server_unreachable))
-            }
+        if (isNetworkException(rootCause)) {
+            showToastOnMainThread(context.getString(R.string.server_unreachable))
             return
         }
 
@@ -40,12 +41,27 @@ class CrashHandler(private val context: Context) : UncaughtExceptionHandler {
         })
     }
 
-    private fun getRootCause(e: Throwable?): Throwable? {
-        var cause = e
-        while (cause?.cause != null) {
-            cause = cause.cause
+    private fun isNetworkException(throwable: Throwable): Boolean {
+        return throwable is ConnectException ||
+                throwable is UnknownHostException ||
+                throwable is SocketTimeoutException ||
+                throwable is SocketException ||
+                throwable is NoRouteToHostException
+    }
+
+    private fun showToastOnMainThread(message: String) {
+        if (Looper.myLooper() == Looper.getMainLooper()) {
+            context.showToastLong(message)
+        } else {
+            android.os.Handler(Looper.getMainLooper()).post {
+                context.showToastLong(message)
+            }
         }
-        return cause
+    }
+
+    private tailrec fun getRootCause(throwable: Throwable): Throwable {
+        val cause = throwable.cause
+        return if (cause == null) throwable else getRootCause(cause)
     }
 
     private fun getCauseMessage(e: Throwable?): String? {


### PR DESCRIPTION
## Summary
- Show a user-friendly toast message ("Server unreachable") for network errors (IOException) instead of opening the crash report page
- Provides better UX for common network issues like ConnectException when FreshRSS server is unavailable

## Changes
- Modified `CrashHandler.kt` to detect IOException at the root of the exception chain
- When network errors occur, display a toast and return early instead of launching CrashReportActivity

Closes #27

Made with [Cursor](https://cursor.com)