### PR TITLE
fix: FreshRSS server URL changes take effect immediately

### DIFF
--- a/app/src/main/java/me/ash/reader/ui/page/settings/accounts/AccountViewModel.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/accounts/AccountViewModel.kt
@@ -59,7 +59,9 @@ class AccountViewModel @Inject constructor(
     fun update(accountId: Int, block: Account.() -> Account) {
         applicationScope.launch(ioDispatcher) {
             accountService.update(accountId, block)
-            rssService.get(accountId).clearAuthorization()
+            accountService.getAccountById(accountId)?.let { account ->
+                rssService.get(account.type.id).clearAuthorization()
+            }
         }
     }
 

--- a/app/src/main/java/me/ash/reader/ui/page/settings/accounts/AccountViewModel.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/accounts/AccountViewModel.kt
@@ -58,9 +58,10 @@ class AccountViewModel @Inject constructor(
 
     fun update(accountId: Int, block: Account.() -> Account) {
         applicationScope.launch(ioDispatcher) {
-            accountService.update(accountId, block)
             accountService.getAccountById(accountId)?.let { account ->
-                rssService.get(account.type.id).clearAuthorization()
+                val updatedAccount = account.run(block)
+                accountService.update(updatedAccount)
+                rssService.get(updatedAccount.type.id).clearAuthorization()
             }
         }
     }


### PR DESCRIPTION
## Summary

- Fixes a bug where FreshRSS server URL changes required an app restart to take effect
- The root cause was `AccountViewModel.update()` passing `accountId` (database row ID) to `rssService.get()` which expects `accountTypeId` (1-6 enum value)
- This caused `clearAuthorization()` to be called on the wrong service, so the cached API instance was never cleared

## Test plan

1. Add a FreshRSS account with a valid server URL
2. Go to account settings and change the server URL to a different valid server
3. Verify that syncing uses the new server immediately without needing to restart the app

Closes #26

Made with [Cursor](https://cursor.com)