### PR TITLE
feat(feeds): show article count badge for groups/folders

### DIFF
--- a/app/src/main/java/me/ash/reader/ui/page/home/feeds/FeedsPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/feeds/FeedsPage.kt
@@ -287,7 +287,7 @@ fun FeedsPage(
                                     groupsVisible.getOrPut(group.id, groupListExpand::value)
                                 },
                                 group = group,
-                                importantCount = feeds.sumOf { it.important },
+                                importantCount = remember(feeds) { feeds.sumOf { it.important } },
                                 onExpanded = {
                                     groupsVisible[group.id] =
                                         groupsVisible

--- a/app/src/main/java/me/ash/reader/ui/page/home/feeds/FeedsPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/feeds/FeedsPage.kt
@@ -287,6 +287,7 @@ fun FeedsPage(
                                     groupsVisible.getOrPut(group.id, groupListExpand::value)
                                 },
                                 group = group,
+                                importantCount = feeds.sumOf { it.important },
                                 onExpanded = {
                                     groupsVisible[group.id] =
                                         groupsVisible

--- a/app/src/main/java/me/ash/reader/ui/page/home/feeds/GroupItem.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/feeds/GroupItem.kt
@@ -10,6 +10,7 @@ import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.rounded.ExpandLess
 import androidx.compose.material.icons.rounded.ExpandMore
+import androidx.compose.material3.Badge
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
@@ -36,6 +37,7 @@ fun GroupItem(
     group: Group,
     isExpanded: () -> Boolean,
     groupOptionViewModel: GroupOptionViewModel = hiltViewModel(),
+    importantCount: Int = 0,
     onExpanded: () -> Unit = {},
     onLongClick: () -> Unit = {},
     groupOnClick: () -> Unit = {},
@@ -72,20 +74,37 @@ fun GroupItem(
                 overflow = TextOverflow.Ellipsis,
             )
             Row(
-                modifier = Modifier
-                    .padding(end = 20.dp)
-                    .size(24.dp)
-                    .clip(CircleShape)
-                    .background(MaterialTheme.colorScheme.surfaceContainerHigh)
-                    .clickable { onExpanded() },
-                horizontalArrangement = Arrangement.Center,
+                modifier = Modifier.padding(end = 20.dp),
+                horizontalArrangement = Arrangement.spacedBy(8.dp),
                 verticalAlignment = Alignment.CenterVertically,
             ) {
-                Icon(
-                    imageVector = if (isExpanded()) Icons.Rounded.ExpandLess else Icons.Rounded.ExpandMore,
-                    contentDescription = stringResource(if (isExpanded()) R.string.expand_less else R.string.expand_more),
-                    tint = MaterialTheme.colorScheme.onSecondaryContainer,
-                )
+                if (importantCount > 0) {
+                    Badge(
+                        containerColor = MaterialTheme.colorScheme.surfaceContainerHigh,
+                        contentColor = MaterialTheme.colorScheme.outline,
+                        content = {
+                            Text(
+                                text = importantCount.toString(),
+                                style = MaterialTheme.typography.labelSmall
+                            )
+                        },
+                    )
+                }
+                Row(
+                    modifier = Modifier
+                        .size(24.dp)
+                        .clip(CircleShape)
+                        .background(MaterialTheme.colorScheme.surfaceContainerHigh)
+                        .clickable { onExpanded() },
+                    horizontalArrangement = Arrangement.Center,
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Icon(
+                        imageVector = if (isExpanded()) Icons.Rounded.ExpandLess else Icons.Rounded.ExpandMore,
+                        contentDescription = stringResource(if (isExpanded()) R.string.expand_less else R.string.expand_more),
+                        tint = MaterialTheme.colorScheme.onSecondaryContainer,
+                    )
+                }
             }
         }
         Spacer(modifier = Modifier.height(22.dp))

--- a/app/src/main/java/me/ash/reader/ui/page/settings/color/feeds/FeedsPagePreview.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/color/feeds/FeedsPagePreview.kt
@@ -88,6 +88,7 @@ fun FeedsPagePreview(
             GroupItem(
                 isExpanded = { groupListExpand.value },
                 group = generateGroupPreview(),
+                importantCount = 100,
             )
             FeedItemExpandSwitcher(
                 isExpanded = groupListExpand.value


### PR DESCRIPTION
## Summary

- Display the total article count (important count) for each group/folder in the feeds list
- Badge is positioned to the left of the expand/collapse button
- Uses the same styling as individual feed counts for consistency

## Screenshot

The "Default" folder now shows "8" (the sum of articles from all feeds in the folder):

<img width="300" src="https://github.com/user-attachments/assets/6f0fe4c8-5a10-4149-b9bc-41bab4241ec4" />

## Test plan

- [x] Build succeeds
- [x] Verified in emulator - folder article count is displayed correctly
- [x] Count matches the sum of individual feed counts within the folder

Closes #25