### PR TITLE
Sort feeds alphabetically, use FreshRSS sortid ordering

### DIFF
--- a/app/schemas/me.ash.reader.infrastructure.db.AndroidDatabase/10.json
+++ b/app/schemas/me.ash.reader.infrastructure.db.AndroidDatabase/10.json
@@ -1,0 +1,493 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 10,
+    "identityHash": "bc6d00e598a7942be4c3dfd0177f593c",
+    "entities": [
+      {
+        "tableName": "account",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `name` TEXT NOT NULL, `type` INTEGER NOT NULL, `updateAt` INTEGER, `lastArticleId` TEXT, `syncInterval` INTEGER NOT NULL DEFAULT 30, `syncOnStart` INTEGER NOT NULL DEFAULT 0, `syncOnlyOnWiFi` INTEGER NOT NULL DEFAULT 0, `syncOnlyWhenCharging` INTEGER NOT NULL DEFAULT 0, `keepArchived` INTEGER NOT NULL DEFAULT 2592000000, `syncBlockList` TEXT NOT NULL DEFAULT '', `securityKey` TEXT DEFAULT 'CvJ1PKM8EW8=')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updateAt",
+            "columnName": "updateAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastArticleId",
+            "columnName": "lastArticleId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncInterval",
+            "columnName": "syncInterval",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "30"
+          },
+          {
+            "fieldPath": "syncOnStart",
+            "columnName": "syncOnStart",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "syncOnlyOnWiFi",
+            "columnName": "syncOnlyOnWiFi",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "syncOnlyWhenCharging",
+            "columnName": "syncOnlyWhenCharging",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "keepArchived",
+            "columnName": "keepArchived",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "2592000000"
+          },
+          {
+            "fieldPath": "syncBlockList",
+            "columnName": "syncBlockList",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "securityKey",
+            "columnName": "securityKey",
+            "affinity": "TEXT",
+            "defaultValue": "'CvJ1PKM8EW8='"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "feed",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `icon` TEXT, `url` TEXT NOT NULL, `groupId` TEXT NOT NULL, `accountId` INTEGER NOT NULL, `isNotification` INTEGER NOT NULL, `isFullContent` INTEGER NOT NULL, `isBrowser` INTEGER NOT NULL DEFAULT 0, `sortOrder` INTEGER DEFAULT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`groupId`) REFERENCES `group`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isNotification",
+            "columnName": "isNotification",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFullContent",
+            "columnName": "isFullContent",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isBrowser",
+            "columnName": "isBrowser",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_feed_groupId",
+            "unique": false,
+            "columnNames": [
+              "groupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_groupId` ON `${TABLE_NAME}` (`groupId`)"
+          },
+          {
+            "name": "index_feed_accountId",
+            "unique": false,
+            "columnNames": [
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_accountId` ON `${TABLE_NAME}` (`accountId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "group",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "groupId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "article",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `date` INTEGER NOT NULL, `title` TEXT NOT NULL, `author` TEXT, `rawDescription` TEXT NOT NULL, `shortDescription` TEXT NOT NULL, `fullContent` TEXT, `img` TEXT, `link` TEXT NOT NULL, `feedId` TEXT NOT NULL, `accountId` INTEGER NOT NULL, `isUnread` INTEGER NOT NULL, `isStarred` INTEGER NOT NULL, `isReadLater` INTEGER NOT NULL, `updateAt` INTEGER, PRIMARY KEY(`id`), FOREIGN KEY(`feedId`) REFERENCES `feed`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "rawDescription",
+            "columnName": "rawDescription",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shortDescription",
+            "columnName": "shortDescription",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fullContent",
+            "columnName": "fullContent",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "img",
+            "columnName": "img",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "link",
+            "columnName": "link",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feedId",
+            "columnName": "feedId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnread",
+            "columnName": "isUnread",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isStarred",
+            "columnName": "isStarred",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isReadLater",
+            "columnName": "isReadLater",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updateAt",
+            "columnName": "updateAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_article_feedId",
+            "unique": false,
+            "columnNames": [
+              "feedId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_article_feedId` ON `${TABLE_NAME}` (`feedId`)"
+          },
+          {
+            "name": "index_article_accountId",
+            "unique": false,
+            "columnNames": [
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_article_accountId` ON `${TABLE_NAME}` (`accountId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "feed",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "feedId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "group",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `accountId` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_group_accountId",
+            "unique": false,
+            "columnNames": [
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_accountId` ON `${TABLE_NAME}` (`accountId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "archived_article",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `feedId` TEXT NOT NULL, `link` TEXT NOT NULL, FOREIGN KEY(`feedId`) REFERENCES `feed`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feedId",
+            "columnName": "feedId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "link",
+            "columnName": "link",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_archived_article_feedId",
+            "unique": false,
+            "columnNames": [
+              "feedId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_archived_article_feedId` ON `${TABLE_NAME}` (`feedId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "feed",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "feedId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "pending_read_state_op",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`articleId` TEXT NOT NULL, `accountId` INTEGER NOT NULL, `feedId` TEXT NOT NULL, `isUnread` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, PRIMARY KEY(`articleId`))",
+        "fields": [
+          {
+            "fieldPath": "articleId",
+            "columnName": "articleId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feedId",
+            "columnName": "feedId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnread",
+            "columnName": "isUnread",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "articleId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_pending_read_state_op_accountId",
+            "unique": false,
+            "columnNames": [
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pending_read_state_op_accountId` ON `${TABLE_NAME}` (`accountId`)"
+          },
+          {
+            "name": "index_pending_read_state_op_feedId",
+            "unique": false,
+            "columnNames": [
+              "feedId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pending_read_state_op_feedId` ON `${TABLE_NAME}` (`feedId`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'bc6d00e598a7942be4c3dfd0177f593c')"
+    ]
+  }
+}

--- a/app/src/main/java/me/ash/reader/domain/data/FeedSorting.kt
+++ b/app/src/main/java/me/ash/reader/domain/data/FeedSorting.kt
@@ -1,0 +1,31 @@
+package me.ash.reader.domain.data
+
+import me.ash.reader.domain.model.feed.Feed
+import me.ash.reader.domain.model.group.GroupWithFeed
+
+fun sortFeedsAlphabetically(feeds: List<Feed>): List<Feed> {
+    return feeds.sortedWith(compareBy(String.CASE_INSENSITIVE_ORDER) { it.name })
+}
+
+fun sortFeedsBySortOrder(feeds: List<Feed>): List<Feed> {
+    return feeds.sortedWith(
+        compareBy<Feed> { it.sortOrder ?: 0 }
+            .thenBy(String.CASE_INSENSITIVE_ORDER) { it.name }
+    )
+}
+
+fun sortGroupWithFeeds(groupWithFeed: GroupWithFeed, useSortOrder: Boolean): GroupWithFeed {
+    val sortedFeeds = if (useSortOrder) {
+        sortFeedsBySortOrder(groupWithFeed.feeds)
+    } else {
+        sortFeedsAlphabetically(groupWithFeed.feeds)
+    }
+    return groupWithFeed.copy(feeds = sortedFeeds.toMutableList())
+}
+
+fun sortGroupWithFeedsList(
+    groups: List<GroupWithFeed>,
+    useSortOrder: Boolean
+): List<GroupWithFeed> {
+    return groups.map { sortGroupWithFeeds(it, useSortOrder) }
+}

--- a/app/src/main/java/me/ash/reader/domain/data/FeedSorting.kt
+++ b/app/src/main/java/me/ash/reader/domain/data/FeedSorting.kt
@@ -9,7 +9,7 @@ fun sortFeedsAlphabetically(feeds: List<Feed>): List<Feed> {
 
 fun sortFeedsBySortOrder(feeds: List<Feed>): List<Feed> {
     return feeds.sortedWith(
-        compareBy<Feed> { it.sortOrder ?: Long.MAX_VALUE }
+        compareBy<Feed> { it.sortOrder ?: Int.MAX_VALUE }
             .thenBy(String.CASE_INSENSITIVE_ORDER) { it.name }
     )
 }

--- a/app/src/main/java/me/ash/reader/domain/data/FeedSorting.kt
+++ b/app/src/main/java/me/ash/reader/domain/data/FeedSorting.kt
@@ -9,7 +9,7 @@ fun sortFeedsAlphabetically(feeds: List<Feed>): List<Feed> {
 
 fun sortFeedsBySortOrder(feeds: List<Feed>): List<Feed> {
     return feeds.sortedWith(
-        compareBy<Feed> { it.sortOrder ?: 0 }
+        compareBy<Feed> { it.sortOrder ?: 0L }
             .thenBy(String.CASE_INSENSITIVE_ORDER) { it.name }
     )
 }

--- a/app/src/main/java/me/ash/reader/domain/data/FeedSorting.kt
+++ b/app/src/main/java/me/ash/reader/domain/data/FeedSorting.kt
@@ -9,7 +9,7 @@ fun sortFeedsAlphabetically(feeds: List<Feed>): List<Feed> {
 
 fun sortFeedsBySortOrder(feeds: List<Feed>): List<Feed> {
     return feeds.sortedWith(
-        compareBy<Feed> { it.sortOrder ?: 0L }
+        compareBy<Feed> { it.sortOrder ?: Long.MAX_VALUE }
             .thenBy(String.CASE_INSENSITIVE_ORDER) { it.name }
     )
 }

--- a/app/src/main/java/me/ash/reader/domain/data/GroupWithFeedsListUseCase.kt
+++ b/app/src/main/java/me/ash/reader/domain/data/GroupWithFeedsListUseCase.kt
@@ -50,13 +50,13 @@ class GroupWithFeedsListUseCase @Inject constructor(
         applicationScope.launch {
             filterStateUseCase.filterStateFlow.map { it.filter }
                 .combine(accountFlow) { filter, account ->
-                    filter
+                    filter to (account.type.id == AccountType.FreshRSS.id)
                 }.collectLatest {
                     currentJob?.cancel()
-                    currentJob = when (it) {
-                        Filter.Unread -> pullUnreadFeeds()
-                        Filter.Starred -> pullStarredFeeds()
-                        else -> pullAllFeeds()
+                    currentJob = when (it.first) {
+                        Filter.Unread -> pullUnreadFeeds(useSortOrder = it.second)
+                        Filter.Starred -> pullStarredFeeds(useSortOrder = it.second)
+                        else -> pullAllFeeds(useSortOrder = it.second)
                     }
                 }
         }
@@ -72,11 +72,8 @@ class GroupWithFeedsListUseCase @Inject constructor(
 
     private val hideEmptyGroups get() = settingsProvider.settings.hideEmptyGroups.value
 
-    private val useSortOrder: Boolean
-        get() = accountService.getCurrentAccount()?.type == AccountType.FreshRSS
-
     @OptIn(ExperimentalCoroutinesApi::class)
-    private fun pullAllFeeds(): Job {
+    private fun pullAllFeeds(useSortOrder: Boolean): Job {
         val articleCountMapFlow =
             rssService.get().pullImportant(isStarred = false, isUnread = false)
 
@@ -96,7 +93,7 @@ class GroupWithFeedsListUseCase @Inject constructor(
         }
     }
 
-    private fun pullStarredFeeds(): Job {
+    private fun pullStarredFeeds(useSortOrder: Boolean): Job {
         val starredCountMap = rssService.get().pullImportant(isStarred = true, isUnread = false)
 
         return applicationScope.launch {
@@ -134,7 +131,7 @@ class GroupWithFeedsListUseCase @Inject constructor(
     }
 
     @OptIn(FlowPreview::class)
-    private fun pullUnreadFeeds(): Job {
+    private fun pullUnreadFeeds(useSortOrder: Boolean): Job {
         val unreadCountMapFlow = rssService.get().pullImportant(isStarred = false, isUnread = true)
         return applicationScope.launch {
             combine(

--- a/app/src/main/java/me/ash/reader/domain/data/GroupWithFeedsListUseCase.kt
+++ b/app/src/main/java/me/ash/reader/domain/data/GroupWithFeedsListUseCase.kt
@@ -85,10 +85,14 @@ class GroupWithFeedsListUseCase @Inject constructor(
                     val feedList = it.feeds.map { feed ->
                         feed.copy(important = articleCountMap[feed.id] ?: 0)
                     }
-                    it.copy(feeds = feedList.toMutableList())
+                    val sortedFeedList = if (useSortOrder) {
+                        sortFeedsBySortOrder(feedList)
+                    } else {
+                        sortFeedsAlphabetically(feedList)
+                    }
+                    it.copy(feeds = sortedFeedList.toMutableList())
                 })
-            }.map { sortGroupWithFeedsList(it, useSortOrder) }
-                .flowOn(ioDispatcher).collect { _groupWithFeedsListFlow.value = it }
+            }.flowOn(ioDispatcher).collect { _groupWithFeedsListFlow.value = it }
 
         }
     }
@@ -119,12 +123,11 @@ class GroupWithFeedsListUseCase @Inject constructor(
                     }
 
                     if (groupItem.group.id != defaultGroupId || groupItem.feeds.isNotEmpty()) {
-                        result.add(groupItem)
+                        result.add(sortGroupWithFeeds(groupItem, useSortOrder))
                     }
                 }
                 result
-            }.map { sortGroupWithFeedsList(it, useSortOrder) }
-                .flowOn(ioDispatcher).collect {
+            }.flowOn(ioDispatcher).collect {
                 _groupWithFeedsListFlow.value = it
             }
         }
@@ -163,13 +166,13 @@ class GroupWithFeedsListUseCase @Inject constructor(
                     }
 
                     if (groupItem.group.id != defaultGroupId || groupItem.feeds.isNotEmpty()) {
-                        result.add(groupItem)
+                        result.add(sortGroupWithFeeds(groupItem, useSortOrder))
                     }
 
                 }
                 result
-            }.debounce(200L).map { sortGroupWithFeedsList(it, useSortOrder) }
-                .flowOn(ioDispatcher).collect { _groupWithFeedsListFlow.value = it }
+            }.debounce(200L).flowOn(ioDispatcher)
+                .collect { _groupWithFeedsListFlow.value = it }
         }
     }
 

--- a/app/src/main/java/me/ash/reader/domain/data/GroupWithFeedsListUseCase.kt
+++ b/app/src/main/java/me/ash/reader/domain/data/GroupWithFeedsListUseCase.kt
@@ -171,8 +171,8 @@ class GroupWithFeedsListUseCase @Inject constructor(
 
                 }
                 result
-            }.map { sortGroupWithFeedsList(it, useSortOrder) }
-                .debounce(200L).flowOn(ioDispatcher).collect { _groupWithFeedsListFlow.value = it }
+            }.debounce(200L).map { sortGroupWithFeedsList(it, useSortOrder) }
+                .flowOn(ioDispatcher).collect { _groupWithFeedsListFlow.value = it }
         }
     }
 

--- a/app/src/main/java/me/ash/reader/domain/data/GroupWithFeedsListUseCase.kt
+++ b/app/src/main/java/me/ash/reader/domain/data/GroupWithFeedsListUseCase.kt
@@ -16,6 +16,7 @@ import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.launch
+import me.ash.reader.domain.model.account.AccountType
 import me.ash.reader.domain.model.general.Filter
 import me.ash.reader.domain.model.group.GroupWithFeed
 import me.ash.reader.domain.service.AccountService
@@ -71,6 +72,9 @@ class GroupWithFeedsListUseCase @Inject constructor(
 
     private val hideEmptyGroups get() = settingsProvider.settings.hideEmptyGroups.value
 
+    private val useSortOrder: Boolean
+        get() = accountService.getCurrentAccount()?.type == AccountType.FreshRSS
+
     @OptIn(ExperimentalCoroutinesApi::class)
     private fun pullAllFeeds(): Job {
         val articleCountMapFlow =
@@ -86,7 +90,8 @@ class GroupWithFeedsListUseCase @Inject constructor(
                     }
                     it.copy(feeds = feedList.toMutableList())
                 })
-            }.flowOn(ioDispatcher).collect { _groupWithFeedsListFlow.value = it }
+            }.map { sortGroupWithFeedsList(it, useSortOrder) }
+                .flowOn(ioDispatcher).collect { _groupWithFeedsListFlow.value = it }
 
         }
     }
@@ -121,7 +126,8 @@ class GroupWithFeedsListUseCase @Inject constructor(
                     }
                 }
                 result
-            }.flowOn(ioDispatcher).collect {
+            }.map { sortGroupWithFeedsList(it, useSortOrder) }
+                .flowOn(ioDispatcher).collect {
                 _groupWithFeedsListFlow.value = it
             }
         }
@@ -165,7 +171,8 @@ class GroupWithFeedsListUseCase @Inject constructor(
 
                 }
                 result
-            }.debounce(200L).flowOn(ioDispatcher).collect { _groupWithFeedsListFlow.value = it }
+            }.map { sortGroupWithFeedsList(it, useSortOrder) }
+                .debounce(200L).flowOn(ioDispatcher).collect { _groupWithFeedsListFlow.value = it }
         }
     }
 

--- a/app/src/main/java/me/ash/reader/domain/model/feed/Feed.kt
+++ b/app/src/main/java/me/ash/reader/domain/model/feed/Feed.kt
@@ -35,6 +35,8 @@ data class Feed(
     val isFullContent: Boolean = false,
     @field:ColumnInfo(defaultValue = "0")
     val isBrowser: Boolean = false,
+    @field:ColumnInfo(defaultValue = "NULL")
+    val sortOrder: Int? = null,
     @Ignore val important: Int = 0
 ) {
     constructor(
@@ -46,7 +48,8 @@ data class Feed(
         accountId: Int,
         isNotification: Boolean,
         isFullContent: Boolean,
-        isBrowser: Boolean
+        isBrowser: Boolean,
+        sortOrder: Int?
     ) : this(
         id = id,
         name = name,
@@ -57,6 +60,7 @@ data class Feed(
         isNotification = isNotification,
         isFullContent = isFullContent,
         isBrowser = isBrowser,
+        sortOrder = sortOrder,
         important = 0
     )
 }

--- a/app/src/main/java/me/ash/reader/domain/model/feed/Feed.kt
+++ b/app/src/main/java/me/ash/reader/domain/model/feed/Feed.kt
@@ -36,7 +36,7 @@ data class Feed(
     @field:ColumnInfo(defaultValue = "0")
     val isBrowser: Boolean = false,
     @field:ColumnInfo(defaultValue = "NULL")
-    val sortOrder: Int? = null,
+    val sortOrder: Long? = null,
     @Ignore val important: Int = 0
 ) {
     constructor(
@@ -49,7 +49,7 @@ data class Feed(
         isNotification: Boolean,
         isFullContent: Boolean,
         isBrowser: Boolean,
-        sortOrder: Int?
+        sortOrder: Long?
     ) : this(
         id = id,
         name = name,

--- a/app/src/main/java/me/ash/reader/domain/model/feed/Feed.kt
+++ b/app/src/main/java/me/ash/reader/domain/model/feed/Feed.kt
@@ -36,7 +36,7 @@ data class Feed(
     @field:ColumnInfo(defaultValue = "0")
     val isBrowser: Boolean = false,
     @field:ColumnInfo(defaultValue = "NULL")
-    val sortOrder: Long? = null,
+    val sortOrder: Int? = null,
     @Ignore val important: Int = 0
 ) {
     constructor(
@@ -49,7 +49,7 @@ data class Feed(
         isNotification: Boolean,
         isFullContent: Boolean,
         isBrowser: Boolean,
-        sortOrder: Long?
+        sortOrder: Int?
     ) : this(
         id = id,
         name = name,

--- a/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
@@ -454,7 +454,7 @@ constructor(
                                 groupId = group.id,
                                 accountId = accountId,
                                 icon = normalizeFreshRssIconUrl(it.iconUrl, normalizedIconBaseUrl),
-                                sortOrder = it.sortid?.toLongOrNull(16),
+                                sortOrder = it.sortid?.toIntOrNull(16),
                             )
                         }
                     }

--- a/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
@@ -454,7 +454,7 @@ constructor(
                                 groupId = group.id,
                                 accountId = accountId,
                                 icon = normalizeFreshRssIconUrl(it.iconUrl, normalizedIconBaseUrl),
-                                sortOrder = it.sortid?.toIntOrNull(),
+                                sortOrder = it.sortid?.toLongOrNull(16),
                             )
                         }
                     }

--- a/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
@@ -454,6 +454,7 @@ constructor(
                                 groupId = group.id,
                                 accountId = accountId,
                                 icon = normalizeFreshRssIconUrl(it.iconUrl, normalizedIconBaseUrl),
+                                sortOrder = it.sortid?.toIntOrNull(),
                             )
                         }
                     }

--- a/app/src/main/java/me/ash/reader/infrastructure/db/AndroidDatabase.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/db/AndroidDatabase.kt
@@ -29,12 +29,13 @@ import java.util.*
         ArchivedArticle::class,
         PendingReadStateOp::class,
     ],
-    version = 9,
+    version = 10,
     autoMigrations = [
         AutoMigration(from = 5, to = 6),
         AutoMigration(from = 6, to = 7),
         AutoMigration(from = 7, to = 8),
         AutoMigration(from = 8, to = 9),
+        AutoMigration(from = 9, to = 10),
     ]
 )
 @TypeConverters(

--- a/app/src/test/java/me/ash/reader/domain/data/FeedSortingTest.kt
+++ b/app/src/test/java/me/ash/reader/domain/data/FeedSortingTest.kt
@@ -70,7 +70,7 @@ class FeedSortingTest {
     }
 
     @Test
-    fun sortFeedsBySortOrder_handlesNullSortOrder_byTreatingAsZero() {
+    fun sortFeedsBySortOrder_placesNullSortOrder_afterExplicitSortOrder() {
         val feeds = mutableListOf(
             testFeed(id = "1", name = "Feed B", sortOrder = null),
             testFeed(id = "2", name = "Feed A", sortOrder = 10),
@@ -79,7 +79,7 @@ class FeedSortingTest {
         val sorted = sortFeedsBySortOrder(feeds)
 
         assertEquals(
-            listOf("Feed B", "Feed A"),
+            listOf("Feed A", "Feed B"),
             sorted.map { it.name }
         )
     }

--- a/app/src/test/java/me/ash/reader/domain/data/FeedSortingTest.kt
+++ b/app/src/test/java/me/ash/reader/domain/data/FeedSortingTest.kt
@@ -148,7 +148,7 @@ class FeedSortingTest {
     private fun testFeed(
         id: String,
         name: String = "Test Feed",
-        sortOrder: Int? = null,
+        sortOrder: Long? = null,
         groupId: String = "1\$Defaults",
         accountId: Int = 1,
     ) = Feed(

--- a/app/src/test/java/me/ash/reader/domain/data/FeedSortingTest.kt
+++ b/app/src/test/java/me/ash/reader/domain/data/FeedSortingTest.kt
@@ -1,0 +1,173 @@
+package me.ash.reader.domain.data
+
+import me.ash.reader.domain.model.feed.Feed
+import me.ash.reader.domain.model.group.Group
+import me.ash.reader.domain.model.group.GroupWithFeed
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class FeedSortingTest {
+
+    @Test
+    fun sortFeedsAlphabetically_sortsFeeds_byNameCaseInsensitive() {
+        val feeds = mutableListOf(
+            testFeed(id = "1", name = "Zebra Feed"),
+            testFeed(id = "2", name = "apple Feed"),
+            testFeed(id = "3", name = "Banana Feed"),
+        )
+
+        val sorted = sortFeedsAlphabetically(feeds)
+
+        assertEquals(
+            listOf("apple Feed", "Banana Feed", "Zebra Feed"),
+            sorted.map { it.name }
+        )
+    }
+
+    @Test
+    fun sortFeedsAlphabetically_preservesOriginalList() {
+        val feeds = mutableListOf(
+            testFeed(id = "1", name = "Zebra"),
+            testFeed(id = "2", name = "Apple"),
+        )
+        val originalOrder = feeds.map { it.id }
+
+        sortFeedsAlphabetically(feeds)
+
+        assertEquals(originalOrder, feeds.map { it.id })
+    }
+
+    @Test
+    fun sortFeedsBySortOrder_sortsFeeds_bySortOrderAscending() {
+        val feeds = mutableListOf(
+            testFeed(id = "1", name = "Feed C", sortOrder = 30),
+            testFeed(id = "2", name = "Feed A", sortOrder = 10),
+            testFeed(id = "3", name = "Feed B", sortOrder = 20),
+        )
+
+        val sorted = sortFeedsBySortOrder(feeds)
+
+        assertEquals(
+            listOf("Feed A", "Feed B", "Feed C"),
+            sorted.map { it.name }
+        )
+    }
+
+    @Test
+    fun sortFeedsBySortOrder_fallsBackToAlphabetical_whenSortOrderEqual() {
+        val feeds = mutableListOf(
+            testFeed(id = "1", name = "Zebra", sortOrder = 0),
+            testFeed(id = "2", name = "Apple", sortOrder = 0),
+            testFeed(id = "3", name = "Banana", sortOrder = 0),
+        )
+
+        val sorted = sortFeedsBySortOrder(feeds)
+
+        assertEquals(
+            listOf("Apple", "Banana", "Zebra"),
+            sorted.map { it.name }
+        )
+    }
+
+    @Test
+    fun sortFeedsBySortOrder_handlesNullSortOrder_byTreatingAsZero() {
+        val feeds = mutableListOf(
+            testFeed(id = "1", name = "Feed B", sortOrder = null),
+            testFeed(id = "2", name = "Feed A", sortOrder = 10),
+        )
+
+        val sorted = sortFeedsBySortOrder(feeds)
+
+        assertEquals(
+            listOf("Feed B", "Feed A"),
+            sorted.map { it.name }
+        )
+    }
+
+    @Test
+    fun sortGroupWithFeeds_sortsFeeds_alphabeticallyWhenNotFreshRSS() {
+        val groupWithFeed = GroupWithFeed(
+            group = testGroup(id = "g1", name = "Tech"),
+            feeds = mutableListOf(
+                testFeed(id = "1", name = "Zebra", sortOrder = 10),
+                testFeed(id = "2", name = "Apple", sortOrder = 20),
+            )
+        )
+
+        val sorted = sortGroupWithFeeds(groupWithFeed, useSortOrder = false)
+
+        assertEquals(
+            listOf("Apple", "Zebra"),
+            sorted.feeds.map { it.name }
+        )
+    }
+
+    @Test
+    fun sortGroupWithFeeds_sortsFeeds_bySortOrderWhenFreshRSS() {
+        val groupWithFeed = GroupWithFeed(
+            group = testGroup(id = "g1", name = "Tech"),
+            feeds = mutableListOf(
+                testFeed(id = "1", name = "Zebra", sortOrder = 10),
+                testFeed(id = "2", name = "Apple", sortOrder = 20),
+            )
+        )
+
+        val sorted = sortGroupWithFeeds(groupWithFeed, useSortOrder = true)
+
+        assertEquals(
+            listOf("Zebra", "Apple"),
+            sorted.feeds.map { it.name }
+        )
+    }
+
+    @Test
+    fun sortGroupWithFeedsList_sortsAllGroups() {
+        val groups = listOf(
+            GroupWithFeed(
+                group = testGroup(id = "g1", name = "Tech"),
+                feeds = mutableListOf(
+                    testFeed(id = "1", name = "Zebra"),
+                    testFeed(id = "2", name = "Apple"),
+                )
+            ),
+            GroupWithFeed(
+                group = testGroup(id = "g2", name = "News"),
+                feeds = mutableListOf(
+                    testFeed(id = "3", name = "CNN"),
+                    testFeed(id = "4", name = "BBC"),
+                )
+            ),
+        )
+
+        val sorted = sortGroupWithFeedsList(groups, useSortOrder = false)
+
+        assertEquals(listOf("Apple", "Zebra"), sorted[0].feeds.map { it.name })
+        assertEquals(listOf("BBC", "CNN"), sorted[1].feeds.map { it.name })
+    }
+
+    private fun testFeed(
+        id: String,
+        name: String = "Test Feed",
+        sortOrder: Int? = null,
+        groupId: String = "1\$Defaults",
+        accountId: Int = 1,
+    ) = Feed(
+        id = id,
+        name = name,
+        icon = null,
+        url = "https://example.com/feed",
+        groupId = groupId,
+        accountId = accountId,
+        sortOrder = sortOrder,
+    )
+
+    private fun testGroup(
+        id: String,
+        name: String = "Default",
+        accountId: Int = 1,
+    ) = Group(
+        id = id,
+        name = name,
+        accountId = accountId,
+    )
+}

--- a/app/src/test/java/me/ash/reader/domain/data/FeedSortingTest.kt
+++ b/app/src/test/java/me/ash/reader/domain/data/FeedSortingTest.kt
@@ -148,7 +148,7 @@ class FeedSortingTest {
     private fun testFeed(
         id: String,
         name: String = "Test Feed",
-        sortOrder: Long? = null,
+        sortOrder: Int? = null,
         groupId: String = "1\$Defaults",
         accountId: Int = 1,
     ) = Feed(


### PR DESCRIPTION
Implements issue #44.

- Sorts feeds alphabetically for non-FreshRSS accounts.
- Preserves FreshRSS subscription order via .
- Adds tests and the Room schema migration.

Fixes #44