### PR TITLE
fix(feeds): sync remote subscriptions after add

### DIFF
--- a/app/src/main/java/me/ash/reader/domain/service/AbstractRssRepository.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/AbstractRssRepository.kt
@@ -46,6 +46,7 @@ abstract class AbstractRssRepository(
     open val moveSubscription: Boolean = true
     open val deleteSubscription: Boolean = true
     open val updateSubscription: Boolean = true
+    open val syncAfterSubscribe: Boolean = true
 
     open suspend fun validCredentials(account: Account) {}
 
@@ -60,7 +61,7 @@ abstract class AbstractRssRepository(
         isNotification: Boolean,
         isFullContent: Boolean,
         isBrowser: Boolean,
-    ) {
+    ): String {
         val accountId = accountService.getCurrentAccountId()
         val feed =
             Feed(
@@ -78,6 +79,7 @@ abstract class AbstractRssRepository(
             searchedFeed.entries.map { rssHelper.buildArticleFromSyndEntry(feed, accountId, it) }
         feedDao.insert(feed)
         articleDao.insertList(articles.map { it.copy(feedId = feed.id) })
+        return feed.id
     }
 
     open suspend fun addGroup(destFeed: Feed?, newGroupName: String): String {

--- a/app/src/main/java/me/ash/reader/domain/service/AbstractRssRepository.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/AbstractRssRepository.kt
@@ -192,6 +192,15 @@ abstract class AbstractRssRepository(
         )
     }
 
+    fun syncFeedAsync(feedId: String) {
+        val inputData =
+            workDataOf(
+                "accountId" to accountService.getCurrentAccountId(),
+                "feedId" to feedId,
+            )
+        SyncWorker.enqueueOneTimeWorkForFeed(workManager, inputData, feedId)
+    }
+
     fun initSync() {
         accountService.getCurrentAccount().let {
             val syncOnStart = it.syncOnStart.value

--- a/app/src/main/java/me/ash/reader/domain/service/FeverRssService.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/FeverRssService.kt
@@ -99,7 +99,7 @@ constructor(
         isNotification: Boolean,
         isFullContent: Boolean,
         isBrowser: Boolean,
-    ) {
+    ): String {
         throw FeverAPIException("Unsupported")
     }
 

--- a/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
@@ -153,7 +153,7 @@ constructor(
         isNotification: Boolean,
         isFullContent: Boolean,
         isBrowser: Boolean,
-    ) {
+    ): String {
         val accountId = accountService.getCurrentAccountId()
         val quickAdd = getGoogleReaderAPI().subscriptionQuickAdd(feedLink)
         val feedId = quickAdd.streamId?.ofFeedStreamIdToId()
@@ -167,9 +167,10 @@ constructor(
                 destCategoryId = groupId.dollarLast(),
                 destFeedName = feedTitle,
             )
+        val localFeedId = accountId.spacerDollar(feedId)
         feedDao.insert(
             Feed(
-                id = accountId.spacerDollar(feedId),
+                id = localFeedId,
                 name = feedTitle,
                 url = feedLink,
                 groupId = groupId,
@@ -179,10 +180,7 @@ constructor(
                 isBrowser = isBrowser,
             )
         )
-        // TODO: When users need to subscribe to multiple feeds continuously, this makes them
-        // uncomfortable.
-        //  It is necessary to make syncWork support synchronizing individual specified feeds.
-        // super.doSyncOneTime()
+        return localFeedId
     }
 
     override suspend fun addGroup(destFeed: Feed?, newGroupName: String): String {

--- a/app/src/main/java/me/ash/reader/domain/service/LocalRssService.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/LocalRssService.kt
@@ -55,6 +55,8 @@ constructor(
         accountService,
     ) {
 
+    override val syncAfterSubscribe: Boolean = false
+
     override suspend fun sync(
         accountId: Int,
         feedId: String?,

--- a/app/src/main/java/me/ash/reader/domain/service/SyncWorker.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/SyncWorker.kt
@@ -97,6 +97,20 @@ constructor(
                 .enqueue()
         }
 
+        fun enqueueOneTimeWorkForFeed(workManager: WorkManager, inputData: Data, feedId: String) {
+            workManager
+                .beginUniqueWork(
+                    "SYNC_FEED_$feedId",
+                    ExistingWorkPolicy.KEEP,
+                    OneTimeWorkRequestBuilder<SyncWorker>()
+                        .addTag(SYNC_TAG)
+                        .addTag(ONETIME_WORK_TAG)
+                        .setInputData(inputData)
+                        .build(),
+                )
+                .enqueue()
+        }
+
         fun enqueuePeriodicWork(account: Account, workManager: WorkManager) {
             val syncInterval = account.syncInterval
             val syncOnlyWhenCharging = account.syncOnlyWhenCharging

--- a/app/src/main/java/me/ash/reader/ui/page/home/feeds/subscribe/SubscribeViewModel.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/feeds/subscribe/SubscribeViewModel.kt
@@ -183,9 +183,9 @@ constructor(
 
         applicationScope.launch {
             val searchedFeed = state.searchedFeed
-            rssService
-                .get()
-                .subscribe(
+            val service = rssService.get()
+            val feedId =
+                service.subscribe(
                     searchedFeed = searchedFeed,
                     feedLink = state.feedLink,
                     groupId = state.selectedGroupId,
@@ -194,6 +194,9 @@ constructor(
                     isBrowser = state.browser,
                 )
             hideDrawer()
+            if (service.syncAfterSubscribe) {
+                service.doSyncOneTime(feedId = feedId)
+            }
         }
     }
 

--- a/app/src/main/java/me/ash/reader/ui/page/home/feeds/subscribe/SubscribeViewModel.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/feeds/subscribe/SubscribeViewModel.kt
@@ -195,7 +195,7 @@ constructor(
                 )
             hideDrawer()
             if (service.syncAfterSubscribe) {
-                service.doSyncOneTime(feedId = feedId)
+                service.syncFeedAsync(feedId)
             }
         }
     }


### PR DESCRIPTION
Closes #42 

- Skip post-subscribe sync for local providers
- Keep post-subscribe sync for remote-backed providers
- Use feed-scoped sync after subscribe