### PR TITLE
fix(unread): keep read articles visible after returning from reader

### DIFF
--- a/app/src/main/java/me/ash/reader/domain/data/DiffMapHolder.kt
+++ b/app/src/main/java/me/ash/reader/domain/data/DiffMapHolder.kt
@@ -96,7 +96,7 @@ class DiffMapHolder @Inject constructor(
     private fun init(account: Account) {
         userCacheDir = cacheDir.resolve(account.id.toString())
         if (account.type == AccountType.Local) {
-            commitLocalPendingReadStateOps(account.id)
+            account.id?.let(::commitLocalPendingReadStateOps)
         }
         commitDiffsFromCache()
         if (account.type != AccountType.Local) {

--- a/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
@@ -45,7 +45,6 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -227,15 +226,9 @@ fun FlowPage(
         }
     }
 
-    DisposableEffect(filterUiState.filter) {
+    LaunchedEffect(filterUiState.filter) {
         val isUnread = filterUiState.filter.isUnread()
         viewModel.setDeferDbCommits(isUnread)
-        onDispose {
-            if (isUnread) {
-                viewModel.setDeferDbCommits(false)
-                viewModel.flushDeferredDiffs()
-            }
-        }
     }
 
     val topAppBarState = rememberTopAppBarState()
@@ -385,6 +378,10 @@ fun FlowPage(
                                 tint = MaterialTheme.colorScheme.onSurface,
                             ) {
                                 onSearch = false
+                                if (filterUiState.filter.isUnread()) {
+                                    viewModel.setDeferDbCommits(false)
+                                    viewModel.flushDeferredDiffs()
+                                }
                                 onNavigateUp()
                             }
                         },

--- a/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
@@ -455,7 +455,9 @@ fun FlowPage(
                 }
             },
             content = {
-                BackHandler(enabled = !onSearch && !markAsRead) { navigateUpWithFlushIfUnread() }
+                BackHandler(enabled = !isTwoPane && !onSearch && !markAsRead) {
+                    navigateUpWithFlushIfUnread()
+                }
 
                 RYExtensibleVisibility(modifier = Modifier.zIndex(1f), visible = onSearch) {
                     BackHandler(onSearch) { onSearch = false }

--- a/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
@@ -231,6 +231,15 @@ fun FlowPage(
         viewModel.setDeferDbCommits(isUnread)
     }
 
+    val navigateUpWithFlushIfUnread = {
+        onSearch = false
+        if (filterUiState.filter.isUnread()) {
+            viewModel.setDeferDbCommits(false)
+            viewModel.flushDeferredDiffs()
+        }
+        onNavigateUp()
+    }
+
     val topAppBarState = rememberTopAppBarState()
 
     val scrollBehavior = TopAppBarDefaults.exitUntilCollapsedScrollBehavior(topAppBarState)
@@ -377,12 +386,7 @@ fun FlowPage(
                                 contentDescription = stringResource(R.string.back),
                                 tint = MaterialTheme.colorScheme.onSurface,
                             ) {
-                                onSearch = false
-                                if (filterUiState.filter.isUnread()) {
-                                    viewModel.setDeferDbCommits(false)
-                                    viewModel.flushDeferredDiffs()
-                                }
-                                onNavigateUp()
+                                navigateUpWithFlushIfUnread()
                             }
                         },
                         actions = {
@@ -451,6 +455,8 @@ fun FlowPage(
                 }
             },
             content = {
+                BackHandler(enabled = !onSearch && !markAsRead) { navigateUpWithFlushIfUnread() }
+
                 RYExtensibleVisibility(modifier = Modifier.zIndex(1f), visible = onSearch) {
                     BackHandler(onSearch) { onSearch = false }
                     SearchBar(


### PR DESCRIPTION
Closes #51

The fix is verified:

  1. Before the fix: When opening an article from the Unread view and returning, the article would completely
     disappear from the list.

  2. After the fix: When opening an article from the Unread view and returning, the article remains visible but is
     grayed out, indicating it has been read while still maintaining visibility in the Unread view.

  The fix involved:
  • Replacing DisposableEffect with LaunchedEffect in FlowPage.kt to prevent premature flushing of deferred
    read-state commits when navigating to the reading page
  • Moving the explicit flush logic to the back navigation handler, which only triggers when the user truly
    navigates away from the Unread filter (not when just viewing an article)

  Verification complete - the fix is working correctly in the emulator.
