### PR TITLE
fix(flow): preserve list position when returning from reader

### DIFF
--- a/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
@@ -147,8 +147,15 @@ fun FlowPage(
 
     val filterUiState = pagerData.filterState
 
-    val listStateKey = "${filterUiState.filter}|${filterUiState.group?.id}|${filterUiState.feed?.id}"
-    val listState = rememberSaveable(listStateKey, saver = LazyListState.Saver) { LazyListState(0, 0) }
+    val listState =
+        rememberSaveable(
+            filterUiState.filter,
+            filterUiState.group?.id,
+            filterUiState.feed?.id,
+            saver = LazyListState.Saver,
+        ) {
+            LazyListState(0, 0)
+        }
 
     val isTopBarElevated = topBarTonalElevation.value > 0
     val scrolledTopBarContainerColor =

--- a/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
@@ -147,7 +147,8 @@ fun FlowPage(
 
     val filterUiState = pagerData.filterState
 
-    val listState = rememberSaveable(pagerData, saver = LazyListState.Saver) { LazyListState(0, 0) }
+    val listStateKey = "${filterUiState.filter}|${filterUiState.group?.id}|${filterUiState.feed?.id}"
+    val listState = rememberSaveable(listStateKey, saver = LazyListState.Saver) { LazyListState(0, 0) }
 
     val isTopBarElevated = topBarTonalElevation.value > 0
     val scrolledTopBarContainerColor =
@@ -295,24 +296,6 @@ fun FlowPage(
                 if (index != -1) {
                     scrollAppBarToCollapsed()
                     listState.animateScrollToItem(index, scrollOffset = -200)
-                }
-            }
-        }
-    } else {
-        LaunchedEffect(Unit) {
-            if (readerState.articleId != null) {
-                val articleId = readerState.articleId
-
-                val itemList = pagingItems?.itemSnapshotList
-
-                val index =
-                    itemList?.indexOfFirst {
-                        it is ArticleFlowItem.Article && it.articleWithFeed.article.id == articleId
-                    } ?: -1
-
-                if (index != -1) {
-                    snapAppBarToCollapsed()
-                    listState.requestScrollToItem(index, scrollOffset = -400)
                 }
             }
         }


### PR DESCRIPTION
Closes #54

Root Cause

The scroll position was shifting because:
1. The rememberSaveable for listState was keyed on pagerData which changed reference on every flow emission, even
    when the actual filter state didn't change
2. There was a LaunchedEffect(Unit) that would scroll to the article that was just read when returning from the
   reading page

Fix

1. Changed the key for listState from pagerData to a stable string key based on the filter, group ID, and feed
   ID. This ensures the scroll position is only reset when the actual filter changes, not when the pager data
   reference changes.

2. Removed the redundant scroll restoration in the LaunchedEffect(Unit) block for single-pane mode. The
   rememberSaveable now properly preserves the scroll position, so the explicit scroll-to-article logic was
   causing unwanted scroll shifts.