### PR TITLE
fix(reading): keep toolbar visible on non-scrollable pages and at scroll boundaries

### DIFF
--- a/app/src/main/java/me/ash/reader/ui/page/home/reading/PullToLoad.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/reading/PullToLoad.kt
@@ -43,9 +43,8 @@ import kotlin.math.sign
 /**
  * A [NestedScrollConnection] that provides scroll events to a hoisted [state].
  *
- * This connection tracks pull-to-load state for article switching while allowing
- * the native Android 12+ overscroll stretch effect to handle visual feedback.
- * It does NOT consume scroll events at boundaries to let the native overscroll work.
+ * This connection handles pull-to-load/switch behavior by consuming scroll events
+ * at boundaries and moving content accordingly.
  *
  * @param enabled If not enabled, all scroll delta and fling velocity will be ignored.
  * @param scrollState The ScrollState of the content, used to detect boundaries.
@@ -69,15 +68,8 @@ private class ReaderNestedScrollConnection(
         if (source != NestedScrollSource.UserInput) return Offset.Zero
         
         // Let the state handle any pull-back (reducing existing offset)
-        // This is needed for pull-to-load indicator to retract properly
         val consumed = onPreScroll(available.y)
-        if (consumed != 0f) {
-            return Offset(0f, consumed)
-        }
-        
-        // Don't consume scroll events here - let them pass through to 
-        // the scrollable content and then to native overscroll
-        return Offset.Zero
+        return Offset(0f, consumed)
     }
 
     override fun onPostScroll(
@@ -86,14 +78,11 @@ private class ReaderNestedScrollConnection(
         if (!enabled) return Offset.Zero
         if (source != NestedScrollSource.UserInput) return Offset.Zero
         
-        // Track pull state for pull-to-load indicator, but DON'T consume
-        // the scroll delta - return Offset.Zero so native overscroll can work
+        // Consume the overscroll and apply it to pull state
         val delta = available.y
         if (delta != 0f) {
-            // Update the pull state (for pull-to-load indicator)
-            onPostScroll(delta)
-            // Return Zero to NOT consume - let native overscroll handle visual feedback
-            return Offset.Zero
+            val pulled = onPostScroll(delta)
+            return Offset(0f, pulled)
         }
         
         return Offset.Zero

--- a/app/src/main/java/me/ash/reader/ui/page/home/reading/PullToLoad.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/reading/PullToLoad.kt
@@ -8,6 +8,7 @@ import androidx.compose.animation.core.animate
 import androidx.compose.animation.core.animateDecay
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.MutatorMutex
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.offset
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.runtime.Composable
@@ -39,22 +40,20 @@ import me.ash.reader.ui.page.home.reading.PullToLoadDefaults.ContentOffsetMultip
 import kotlin.math.abs
 import kotlin.math.sign
 
-private const val TAG = "PullToLoad"
-
 /**
  * A [NestedScrollConnection] that provides scroll events to a hoisted [state].
  *
- * Note that this modifier must be added above a scrolling container using [Modifier.nestedScroll],
- * such as a lazy column, in order to receive scroll events.
- *
- * And you should manually handle the offset of components
- * with [PullToLoadState.absProgress] or [PullToLoadState.offsetFraction]
+ * This connection tracks pull-to-load state for article switching while allowing
+ * the native Android 12+ overscroll stretch effect to handle visual feedback.
+ * It does NOT consume scroll events at boundaries to let the native overscroll work.
  *
  * @param enabled If not enabled, all scroll delta and fling velocity will be ignored.
+ * @param scrollState The ScrollState of the content, used to detect boundaries.
  * @param onScroll Used for detecting if the reader is scrolling down
  */
 private class ReaderNestedScrollConnection(
     private val enabled: Boolean,
+    private val scrollState: ScrollState?,
     private val onPreScroll: (Float) -> Float,
     private val onPostScroll: (Float) -> Float,
     private val onRelease: () -> Unit,
@@ -65,28 +64,39 @@ private class ReaderNestedScrollConnection(
         available: Offset, source: NestedScrollSource
     ): Offset {
         onScroll?.invoke(available.y)
-        return when {
-            !enabled || available.y == 0f -> Offset.Zero
-
-            // Scroll down to reduce the progress when the offset is currently pulled up, same for the opposite
-            source == NestedScrollSource.UserInput -> {
-                Offset(0f, onPreScroll(available.y))
-            }
-
-            else -> Offset.Zero
+        
+        if (!enabled || available.y == 0f) return Offset.Zero
+        if (source != NestedScrollSource.UserInput) return Offset.Zero
+        
+        // Let the state handle any pull-back (reducing existing offset)
+        // This is needed for pull-to-load indicator to retract properly
+        val consumed = onPreScroll(available.y)
+        if (consumed != 0f) {
+            return Offset(0f, consumed)
         }
-
+        
+        // Don't consume scroll events here - let them pass through to 
+        // the scrollable content and then to native overscroll
+        return Offset.Zero
     }
 
     override fun onPostScroll(
         consumed: Offset, available: Offset, source: NestedScrollSource
-    ): Offset = when {
-        !enabled -> Offset.Zero
-        source == NestedScrollSource.UserInput -> Offset(
-            0f,
-            onPostScroll(available.y)
-        ) // Pull to load
-        else -> Offset.Zero
+    ): Offset {
+        if (!enabled) return Offset.Zero
+        if (source != NestedScrollSource.UserInput) return Offset.Zero
+        
+        // Track pull state for pull-to-load indicator, but DON'T consume
+        // the scroll delta - return Offset.Zero so native overscroll can work
+        val delta = available.y
+        if (delta != 0f) {
+            // Update the pull state (for pull-to-load indicator)
+            onPostScroll(delta)
+            // Return Zero to NOT consume - let native overscroll handle visual feedback
+            return Offset.Zero
+        }
+        
+        return Offset.Zero
     }
 
     override suspend fun onPreFling(available: Velocity): Velocity {
@@ -223,11 +233,6 @@ class PullToLoadState internal constructor(
         } else {
             pullDelta
         }
-        /*
-                Log.d(
-                    TAG,
-                    "onPull: currentOffset = $offsetPulled, pullDelta = $pullDelta, consumed = $consumed"
-                )*/
         offsetPulled += consumed
         return consumed
     }
@@ -325,7 +330,10 @@ private fun Float.signOpposites(f: Float): Boolean = this.sign * f.sign < 0f
  * Default parameter values for [rememberPullToLoadState].
  */
 object PullToLoadDefaults {
-    const val ContentOffsetMultiple = 60
+    /**
+     * Multiplier for content offset during pull. Used by FlowPage for pull-to-sync visual feedback.
+     */
+    const val ContentOffsetMultiple = 100
 
     /**
      * If the indicator is below this threshold offset when it is released, the load action
@@ -343,25 +351,44 @@ object PullToLoadDefaults {
 
 }
 
+/**
+ * A modifier that tracks pull-to-load state and optionally applies content offset.
+ * 
+ * For the reading page, pass [contentOffsetY] = null to disable content offset and
+ * let the native Android 12+ overscroll stretch effect handle visual feedback.
+ * 
+ * For FlowPage (article list), pass a custom [contentOffsetY] function to apply
+ * pull-to-sync visual feedback.
+ *
+ * @param state The [PullToLoadState] to track pull progress.
+ * @param scrollState Optional [ScrollState] for boundary detection.
+ * @param contentOffsetY Optional function to calculate content Y offset from fraction.
+ *        Pass null to disable offset (for reading page with native overscroll).
+ * @param onScroll Callback for scroll events.
+ * @param enabled Whether pull-to-load is enabled.
+ */
 fun Modifier.pullToLoad(
     state: PullToLoadState,
-    contentOffsetY: Density.(Float) -> Int = { fraction ->
+    scrollState: ScrollState? = null,
+    contentOffsetY: (Density.(Float) -> Int)? = { fraction ->
         (ContentOffsetMultiple.dp * fraction).roundToPx()
     },
     onScroll: ((Float) -> Unit)? = null,
     enabled: Boolean = true,
-): Modifier =
-    nestedScroll(
+): Modifier {
+    val base = nestedScroll(
         ReaderNestedScrollConnection(
             enabled = enabled,
+            scrollState = scrollState,
             onPreScroll = state::onPullBack,
             onPostScroll = state::onPull,
             onRelease = state::onRelease,
             onScroll = onScroll
         )
-    ).then(
-        if (enabled) Modifier.offset {
-            IntOffset(x = 0, y = contentOffsetY(state.offsetFraction))
-        }
-        else this
     )
+    return if (contentOffsetY != null) {
+        base.offset { IntOffset(x = 0, y = contentOffsetY(state.offsetFraction)) }
+    } else {
+        base
+    }
+}

--- a/app/src/main/java/me/ash/reader/ui/page/home/reading/PullToLoad.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/reading/PullToLoad.kt
@@ -375,7 +375,7 @@ fun Modifier.pullToLoad(
             onScroll = onScroll
         )
     )
-    return if (contentOffsetY != null) {
+    return if (enabled && contentOffsetY != null) {
         base.offset { IntOffset(x = 0, y = contentOffsetY(state.offsetFraction)) }
     } else {
         base

--- a/app/src/main/java/me/ash/reader/ui/page/home/reading/PullToLoad.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/reading/PullToLoad.kt
@@ -8,7 +8,6 @@ import androidx.compose.animation.core.animate
 import androidx.compose.animation.core.animateDecay
 import androidx.compose.animation.core.spring
 import androidx.compose.foundation.MutatorMutex
-import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.layout.offset
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.runtime.Composable
@@ -47,12 +46,10 @@ import kotlin.math.sign
  * at boundaries and moving content accordingly.
  *
  * @param enabled If not enabled, all scroll delta and fling velocity will be ignored.
- * @param scrollState The ScrollState of the content, used to detect boundaries.
  * @param onScroll Used for detecting if the reader is scrolling down
  */
 private class ReaderNestedScrollConnection(
     private val enabled: Boolean,
-    private val scrollState: ScrollState?,
     private val onPreScroll: (Float) -> Float,
     private val onPostScroll: (Float) -> Float,
     private val onRelease: () -> Unit,
@@ -358,7 +355,6 @@ object PullToLoadDefaults {
  */
 fun Modifier.pullToLoad(
     state: PullToLoadState,
-    scrollState: ScrollState? = null,
     contentOffsetY: (Density.(Float) -> Int)? = { fraction ->
         (ContentOffsetMultiple.dp * fraction).roundToPx()
     },
@@ -368,7 +364,6 @@ fun Modifier.pullToLoad(
     val base = nestedScroll(
         ReaderNestedScrollConnection(
             enabled = enabled,
-            scrollState = scrollState,
             onPreScroll = state::onPullBack,
             onPostScroll = state::onPull,
             onRelease = state::onRelease,

--- a/app/src/main/java/me/ash/reader/ui/page/home/reading/ReaderToolbarState.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/reading/ReaderToolbarState.kt
@@ -1,0 +1,70 @@
+package me.ash.reader.ui.page.home.reading
+
+/**
+ * Determines toolbar visibility based on scroll state.
+ *
+ * Rules:
+ * 1. If content is not scrollable (maxScroll == 0), always show toolbar
+ * 2. If content is scrollable:
+ *    - Show toolbar when at top (scrollPosition == 0)
+ *    - Show toolbar when at bottom (scrollPosition >= maxScroll)
+ *    - Hide toolbar when scrolling down in the middle
+ *    - Show toolbar when scrolling up in the middle
+ * 3. If auto-hide is disabled, always show toolbar
+ */
+object ReaderToolbarState {
+
+    /**
+     * Determines if the toolbar should be visible.
+     *
+     * @param isAutoHideEnabled Whether the auto-hide toolbar preference is enabled
+     * @param isScrollable Whether the content is scrollable (maxScroll > 0)
+     * @param isAtTop Whether scroll position is at the top (scrollPosition == 0 or close to it)
+     * @param isAtBottom Whether scroll position is at the bottom (scrollPosition >= maxScroll)
+     * @param isScrollingDown Whether user is currently scrolling down (negative y delta)
+     * @return true if toolbar should be visible
+     */
+    fun shouldShowToolbar(
+        isAutoHideEnabled: Boolean,
+        isScrollable: Boolean,
+        isAtTop: Boolean,
+        isAtBottom: Boolean,
+        isScrollingDown: Boolean
+    ): Boolean {
+        // If auto-hide is disabled, always show
+        if (!isAutoHideEnabled) return true
+
+        // If content is not scrollable, always show
+        if (!isScrollable) return true
+
+        // If at top or bottom, always show
+        if (isAtTop || isAtBottom) return true
+
+        // In the middle: hide when scrolling down, show when scrolling up
+        return !isScrollingDown
+    }
+
+    /**
+     * Checks if scroll position is at the top.
+     * Uses a small threshold to account for minor scroll offsets.
+     */
+    fun isAtTop(scrollPosition: Int, threshold: Int = 10): Boolean {
+        return scrollPosition <= threshold
+    }
+
+    /**
+     * Checks if scroll position is at the bottom.
+     * Uses a small threshold to account for minor scroll offsets.
+     */
+    fun isAtBottom(scrollPosition: Int, maxScroll: Int, threshold: Int = 10): Boolean {
+        if (maxScroll <= 0) return true // Not scrollable = always at top/bottom
+        return scrollPosition >= maxScroll - threshold
+    }
+
+    /**
+     * Checks if the content is scrollable.
+     */
+    fun isScrollable(maxScroll: Int): Boolean {
+        return maxScroll > 0
+    }
+}

--- a/app/src/main/java/me/ash/reader/ui/page/home/reading/ReadingPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/reading/ReadingPage.kt
@@ -277,7 +277,6 @@ fun ReadingPage(
                                                 modifier = Modifier.pullToLoad(
                                                     state = state,
                                                     scrollState = scrollState,
-                                                    contentOffsetY = null,
                                                 ),
                                                 contentPadding = paddings,
                                                 content = content.text ?: "",

--- a/app/src/main/java/me/ash/reader/ui/page/home/reading/ReadingPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/reading/ReadingPage.kt
@@ -275,7 +275,6 @@ fun ReadingPage(
                                         val contentModifier = if (isPullToSwitchArticleEnabled) {
                                             Modifier.pullToLoad(
                                                 state = state,
-                                                scrollState = scrollState,
                                             )
                                         } else {
                                             Modifier

--- a/app/src/main/java/me/ash/reader/ui/page/home/reading/ReadingPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/reading/ReadingPage.kt
@@ -46,6 +46,7 @@ import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
 import android.widget.FrameLayout
 import kotlin.math.abs
+import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.launch
 import me.ash.reader.R
 import me.ash.reader.infrastructure.android.TextToSpeechManager
@@ -80,6 +81,11 @@ fun ReadingPage(
 
     var isReaderScrollingDown by remember { mutableStateOf(false) }
     var showFullScreenImageViewer by remember { mutableStateOf(false) }
+    
+    // Track scroll position for toolbar visibility
+    var isScrollable by remember { mutableStateOf(false) }
+    var isAtTop by remember { mutableStateOf(true) }
+    var isAtBottom by remember { mutableStateOf(true) }
 
     var currentImageData by remember { mutableStateOf(ImageData()) }
 
@@ -93,12 +99,14 @@ fun ReadingPage(
         fullscreenVideoCallback?.onCustomViewHidden()
     }
 
-    val isShowToolBar =
-        if (LocalReadingAutoHideToolbar.current.value) {
-            readerState.articleId != null && !isReaderScrollingDown
-        } else {
-            true
-        }
+    val isAutoHideEnabled = LocalReadingAutoHideToolbar.current.value
+    val isShowToolBar = readerState.articleId != null && ReaderToolbarState.shouldShowToolbar(
+        isAutoHideEnabled = isAutoHideEnabled,
+        isScrollable = isScrollable,
+        isAtTop = isAtTop,
+        isAtBottom = isAtBottom,
+        isScrollingDown = isReaderScrollingDown
+    )
 
     var showTopDivider by remember { mutableStateOf(false) }
 
@@ -190,14 +198,14 @@ fun ReadingPage(
                                     rememberPullToLoadState(
                                         key = content,
                                         onLoadNext =
-                                            if (isNextArticleAvailable) {
+                                            if (isPullToSwitchArticleEnabled && isNextArticleAvailable) {
                                                 {
                                                     val (id, index) = readerState.nextArticle
                                                     onLoadArticle(id, index)
                                                 }
                                             } else null,
                                         onLoadPrevious =
-                                            if (isPreviousArticleAvailable) {
+                                            if (isPullToSwitchArticleEnabled && isPreviousArticleAvailable) {
                                                 {
                                                     val (id, index) = readerState.previousArticle
                                                     onLoadArticle(id, index)
@@ -225,6 +233,28 @@ fun ReadingPage(
                                         }
                                         .collectAsStateValue(initial = false)
 
+                                // Track scroll position for toolbar visibility
+                                LaunchedEffect(scrollState) {
+                                    var lastPosition = scrollState.value
+                                    snapshotFlow {
+                                        Triple(
+                                            scrollState.value,
+                                            scrollState.maxValue,
+                                            scrollState.maxValue > 0
+                                        )
+                                    }.distinctUntilChanged().collect { (position, maxScroll, scrollable) ->
+                                        isScrollable = scrollable
+                                        isAtTop = ReaderToolbarState.isAtTop(position)
+                                        isAtBottom = ReaderToolbarState.isAtBottom(position, maxScroll)
+                                        // Track scroll direction for toolbar visibility
+                                        val delta = position - lastPosition
+                                        if (abs(delta) > 2) {
+                                            isReaderScrollingDown = delta > 0
+                                        }
+                                        lastPosition = position
+                                    }
+                                }
+
                                 CompositionLocalProvider(
                                     LocalTextStyle provides
                                         LocalTextStyle.current.run {
@@ -242,44 +272,67 @@ fun ReadingPage(
                                         modifier = Modifier.fillMaxSize(),
                                         contentAlignment = Alignment.Center,
                                     ) {
-                                        Content(
-                                            modifier =
-                                                Modifier.pullToLoad(
+                                        if (isPullToSwitchArticleEnabled) {
+                                            Content(
+                                                modifier = Modifier.pullToLoad(
                                                     state = state,
-                                                    onScroll = { f ->
-                                                        if (abs(f) > 2f)
-                                                            isReaderScrollingDown = f < 0f
-                                                    },
-                                                    enabled = isPullToSwitchArticleEnabled,
+                                                    scrollState = scrollState,
+                                                    contentOffsetY = null,
                                                 ),
-                                            contentPadding = paddings,
-                                            content = content.text ?: "",
-                                            feedName = feedName,
-                                            title = title.toString(),
-                                            author = author,
-                                            link = link,
-                                            publishedDate = publishedDate,
-                                            isLoading = content is ReaderState.Loading,
-                                            scrollState = scrollState,
-                                            onImageClick = { imgUrl, altText ->
-                                                currentImageData = ImageData(imgUrl, altText)
-                                                showFullScreenImageViewer = true
-                                            },
-                                            onShowCustomView = { view, callback ->
-                                                android.util.Log.d("ReadingPage", "onShowCustomView lambda called with view=$view")
-                                                fullscreenVideoView = view
-                                                fullscreenVideoCallback = callback
-                                            },
-                                            onHideCustomView = {
-                                                fullscreenVideoView = null
-                                                fullscreenVideoCallback = null
-                                            },
-                                        )
-                                        PullToLoadIndicator(
-                                            state = state,
-                                            canLoadPrevious = isPreviousArticleAvailable,
-                                            canLoadNext = isNextArticleAvailable,
-                                        )
+                                                contentPadding = paddings,
+                                                content = content.text ?: "",
+                                                feedName = feedName,
+                                                title = title.toString(),
+                                                author = author,
+                                                link = link,
+                                                publishedDate = publishedDate,
+                                                isLoading = content is ReaderState.Loading,
+                                                scrollState = scrollState,
+                                                onImageClick = { imgUrl, altText ->
+                                                    currentImageData = ImageData(imgUrl, altText)
+                                                    showFullScreenImageViewer = true
+                                                },
+                                                onShowCustomView = { view, callback ->
+                                                    android.util.Log.d("ReadingPage", "onShowCustomView lambda called with view=$view")
+                                                    fullscreenVideoView = view
+                                                    fullscreenVideoCallback = callback
+                                                },
+                                                onHideCustomView = {
+                                                    fullscreenVideoView = null
+                                                    fullscreenVideoCallback = null
+                                                },
+                                            )
+                                            PullToLoadIndicator(
+                                                state = state,
+                                                canLoadPrevious = isPreviousArticleAvailable,
+                                                canLoadNext = isNextArticleAvailable,
+                                            )
+                                        } else {
+                                            Content(
+                                                contentPadding = paddings,
+                                                content = content.text ?: "",
+                                                feedName = feedName,
+                                                title = title.toString(),
+                                                author = author,
+                                                link = link,
+                                                publishedDate = publishedDate,
+                                                isLoading = content is ReaderState.Loading,
+                                                scrollState = scrollState,
+                                                onImageClick = { imgUrl, altText ->
+                                                    currentImageData = ImageData(imgUrl, altText)
+                                                    showFullScreenImageViewer = true
+                                                },
+                                                onShowCustomView = { view, callback ->
+                                                    android.util.Log.d("ReadingPage", "onShowCustomView lambda called with view=$view")
+                                                    fullscreenVideoView = view
+                                                    fullscreenVideoCallback = callback
+                                                },
+                                                onHideCustomView = {
+                                                    fullscreenVideoView = null
+                                                    fullscreenVideoCallback = null
+                                                },
+                                            )
+                                        }
                                     }
                                 }
                             }

--- a/app/src/main/java/me/ash/reader/ui/page/home/reading/ReadingPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/reading/ReadingPage.kt
@@ -272,64 +272,44 @@ fun ReadingPage(
                                         modifier = Modifier.fillMaxSize(),
                                         contentAlignment = Alignment.Center,
                                     ) {
-                                        if (isPullToSwitchArticleEnabled) {
-                                            Content(
-                                                modifier = Modifier.pullToLoad(
-                                                    state = state,
-                                                    scrollState = scrollState,
-                                                ),
-                                                contentPadding = paddings,
-                                                content = content.text ?: "",
-                                                feedName = feedName,
-                                                title = title.toString(),
-                                                author = author,
-                                                link = link,
-                                                publishedDate = publishedDate,
-                                                isLoading = content is ReaderState.Loading,
+                                        val contentModifier = if (isPullToSwitchArticleEnabled) {
+                                            Modifier.pullToLoad(
+                                                state = state,
                                                 scrollState = scrollState,
-                                                onImageClick = { imgUrl, altText ->
-                                                    currentImageData = ImageData(imgUrl, altText)
-                                                    showFullScreenImageViewer = true
-                                                },
-                                                onShowCustomView = { view, callback ->
-                                                    android.util.Log.d("ReadingPage", "onShowCustomView lambda called with view=$view")
-                                                    fullscreenVideoView = view
-                                                    fullscreenVideoCallback = callback
-                                                },
-                                                onHideCustomView = {
-                                                    fullscreenVideoView = null
-                                                    fullscreenVideoCallback = null
-                                                },
                                             )
+                                        } else {
+                                            Modifier
+                                        }
+                                        Content(
+                                            modifier = contentModifier,
+                                            contentPadding = paddings,
+                                            content = content.text ?: "",
+                                            feedName = feedName,
+                                            title = title.toString(),
+                                            author = author,
+                                            link = link,
+                                            publishedDate = publishedDate,
+                                            isLoading = content is ReaderState.Loading,
+                                            scrollState = scrollState,
+                                            onImageClick = { imgUrl, altText ->
+                                                currentImageData = ImageData(imgUrl, altText)
+                                                showFullScreenImageViewer = true
+                                            },
+                                            onShowCustomView = { view, callback ->
+                                                android.util.Log.d("ReadingPage", "onShowCustomView lambda called with view=$view")
+                                                fullscreenVideoView = view
+                                                fullscreenVideoCallback = callback
+                                            },
+                                            onHideCustomView = {
+                                                fullscreenVideoView = null
+                                                fullscreenVideoCallback = null
+                                            },
+                                        )
+                                        if (isPullToSwitchArticleEnabled) {
                                             PullToLoadIndicator(
                                                 state = state,
                                                 canLoadPrevious = isPreviousArticleAvailable,
                                                 canLoadNext = isNextArticleAvailable,
-                                            )
-                                        } else {
-                                            Content(
-                                                contentPadding = paddings,
-                                                content = content.text ?: "",
-                                                feedName = feedName,
-                                                title = title.toString(),
-                                                author = author,
-                                                link = link,
-                                                publishedDate = publishedDate,
-                                                isLoading = content is ReaderState.Loading,
-                                                scrollState = scrollState,
-                                                onImageClick = { imgUrl, altText ->
-                                                    currentImageData = ImageData(imgUrl, altText)
-                                                    showFullScreenImageViewer = true
-                                                },
-                                                onShowCustomView = { view, callback ->
-                                                    android.util.Log.d("ReadingPage", "onShowCustomView lambda called with view=$view")
-                                                    fullscreenVideoView = view
-                                                    fullscreenVideoCallback = callback
-                                                },
-                                                onHideCustomView = {
-                                                    fullscreenVideoView = null
-                                                    fullscreenVideoCallback = null
-                                                },
                                             )
                                         }
                                     }

--- a/app/src/test/java/me/ash/reader/ui/page/home/reading/ReaderToolbarStateTest.kt
+++ b/app/src/test/java/me/ash/reader/ui/page/home/reading/ReaderToolbarStateTest.kt
@@ -1,0 +1,232 @@
+package me.ash.reader.ui.page.home.reading
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class ReaderToolbarStateTest {
+
+    // ==================== shouldShowToolbar tests ====================
+
+    @Test
+    fun `toolbar visible when auto-hide is disabled`() {
+        // Even when scrolling down in the middle, toolbar should show
+        val result = ReaderToolbarState.shouldShowToolbar(
+            isAutoHideEnabled = false,
+            isScrollable = true,
+            isAtTop = false,
+            isAtBottom = false,
+            isScrollingDown = true
+        )
+        assertTrue("Toolbar should be visible when auto-hide is disabled", result)
+    }
+
+    @Test
+    fun `toolbar visible when content is not scrollable`() {
+        // Short article that doesn't need scrolling - always show toolbar
+        val result = ReaderToolbarState.shouldShowToolbar(
+            isAutoHideEnabled = true,
+            isScrollable = false,
+            isAtTop = true,
+            isAtBottom = true,
+            isScrollingDown = true // Even if trying to scroll down
+        )
+        assertTrue("Toolbar should be visible for non-scrollable content", result)
+    }
+
+    @Test
+    fun `toolbar visible when at top of scrollable content`() {
+        val result = ReaderToolbarState.shouldShowToolbar(
+            isAutoHideEnabled = true,
+            isScrollable = true,
+            isAtTop = true,
+            isAtBottom = false,
+            isScrollingDown = true // Even if scrolling down
+        )
+        assertTrue("Toolbar should be visible at top of content", result)
+    }
+
+    @Test
+    fun `toolbar visible when at bottom of scrollable content`() {
+        val result = ReaderToolbarState.shouldShowToolbar(
+            isAutoHideEnabled = true,
+            isScrollable = true,
+            isAtTop = false,
+            isAtBottom = true,
+            isScrollingDown = true // Even if scrolling down
+        )
+        assertTrue("Toolbar should be visible at bottom of content", result)
+    }
+
+    @Test
+    fun `toolbar hidden when scrolling down in the middle`() {
+        val result = ReaderToolbarState.shouldShowToolbar(
+            isAutoHideEnabled = true,
+            isScrollable = true,
+            isAtTop = false,
+            isAtBottom = false,
+            isScrollingDown = true
+        )
+        assertFalse("Toolbar should be hidden when scrolling down in the middle", result)
+    }
+
+    @Test
+    fun `toolbar visible when scrolling up in the middle`() {
+        val result = ReaderToolbarState.shouldShowToolbar(
+            isAutoHideEnabled = true,
+            isScrollable = true,
+            isAtTop = false,
+            isAtBottom = false,
+            isScrollingDown = false
+        )
+        assertTrue("Toolbar should be visible when scrolling up in the middle", result)
+    }
+
+    // ==================== isAtTop tests ====================
+
+    @Test
+    fun `isAtTop returns true when scroll position is 0`() {
+        assertTrue(ReaderToolbarState.isAtTop(scrollPosition = 0))
+    }
+
+    @Test
+    fun `isAtTop returns true when scroll position is within threshold`() {
+        assertTrue(ReaderToolbarState.isAtTop(scrollPosition = 5, threshold = 10))
+        assertTrue(ReaderToolbarState.isAtTop(scrollPosition = 10, threshold = 10))
+    }
+
+    @Test
+    fun `isAtTop returns false when scroll position exceeds threshold`() {
+        assertFalse(ReaderToolbarState.isAtTop(scrollPosition = 15, threshold = 10))
+        assertFalse(ReaderToolbarState.isAtTop(scrollPosition = 100, threshold = 10))
+    }
+
+    // ==================== isAtBottom tests ====================
+
+    @Test
+    fun `isAtBottom returns true when scroll position equals maxScroll`() {
+        assertTrue(ReaderToolbarState.isAtBottom(scrollPosition = 1000, maxScroll = 1000))
+    }
+
+    @Test
+    fun `isAtBottom returns true when scroll position is within threshold of maxScroll`() {
+        assertTrue(ReaderToolbarState.isAtBottom(scrollPosition = 995, maxScroll = 1000, threshold = 10))
+        assertTrue(ReaderToolbarState.isAtBottom(scrollPosition = 990, maxScroll = 1000, threshold = 10))
+    }
+
+    @Test
+    fun `isAtBottom returns false when scroll position is far from maxScroll`() {
+        assertFalse(ReaderToolbarState.isAtBottom(scrollPosition = 500, maxScroll = 1000, threshold = 10))
+        assertFalse(ReaderToolbarState.isAtBottom(scrollPosition = 980, maxScroll = 1000, threshold = 10))
+    }
+
+    @Test
+    fun `isAtBottom returns true when content is not scrollable`() {
+        // maxScroll <= 0 means not scrollable, so always at bottom
+        assertTrue(ReaderToolbarState.isAtBottom(scrollPosition = 0, maxScroll = 0))
+        assertTrue(ReaderToolbarState.isAtBottom(scrollPosition = 0, maxScroll = -1))
+    }
+
+    // ==================== isScrollable tests ====================
+
+    @Test
+    fun `isScrollable returns false when maxScroll is 0`() {
+        assertFalse(ReaderToolbarState.isScrollable(maxScroll = 0))
+    }
+
+    @Test
+    fun `isScrollable returns false when maxScroll is negative`() {
+        assertFalse(ReaderToolbarState.isScrollable(maxScroll = -1))
+    }
+
+    @Test
+    fun `isScrollable returns true when maxScroll is positive`() {
+        assertTrue(ReaderToolbarState.isScrollable(maxScroll = 1))
+        assertTrue(ReaderToolbarState.isScrollable(maxScroll = 1000))
+    }
+
+    // ==================== Integration scenario tests ====================
+
+    @Test
+    fun `short article scenario - toolbar always visible regardless of scroll attempts`() {
+        // Simulate a short article that fits on screen
+        val maxScroll = 0
+        val isScrollable = ReaderToolbarState.isScrollable(maxScroll)
+
+        // User tries to scroll down
+        val showToolbar = ReaderToolbarState.shouldShowToolbar(
+            isAutoHideEnabled = true,
+            isScrollable = isScrollable,
+            isAtTop = true,
+            isAtBottom = true,
+            isScrollingDown = true
+        )
+        assertTrue("Short article should always show toolbar", showToolbar)
+    }
+
+    @Test
+    fun `long article scenario - toolbar hides when scrolling down in middle`() {
+        // Simulate a long article
+        val maxScroll = 2000
+        val scrollPosition = 500 // Somewhere in the middle
+
+        val isScrollable = ReaderToolbarState.isScrollable(maxScroll)
+        val isAtTop = ReaderToolbarState.isAtTop(scrollPosition)
+        val isAtBottom = ReaderToolbarState.isAtBottom(scrollPosition, maxScroll)
+
+        assertTrue("Long article should be scrollable", isScrollable)
+        assertFalse("Position 500 should not be at top", isAtTop)
+        assertFalse("Position 500 should not be at bottom", isAtBottom)
+
+        val showToolbar = ReaderToolbarState.shouldShowToolbar(
+            isAutoHideEnabled = true,
+            isScrollable = isScrollable,
+            isAtTop = isAtTop,
+            isAtBottom = isAtBottom,
+            isScrollingDown = true
+        )
+        assertFalse("Toolbar should hide when scrolling down in middle", showToolbar)
+    }
+
+    @Test
+    fun `long article scenario - toolbar shows when scrolling to bottom`() {
+        val maxScroll = 2000
+        val scrollPosition = 1995 // At bottom
+
+        val isScrollable = ReaderToolbarState.isScrollable(maxScroll)
+        val isAtTop = ReaderToolbarState.isAtTop(scrollPosition)
+        val isAtBottom = ReaderToolbarState.isAtBottom(scrollPosition, maxScroll)
+
+        assertTrue("Position 1995 should be at bottom", isAtBottom)
+
+        val showToolbar = ReaderToolbarState.shouldShowToolbar(
+            isAutoHideEnabled = true,
+            isScrollable = isScrollable,
+            isAtTop = isAtTop,
+            isAtBottom = isAtBottom,
+            isScrollingDown = true
+        )
+        assertTrue("Toolbar should show at bottom", showToolbar)
+    }
+
+    @Test
+    fun `long article scenario - toolbar shows when scrolling back to top`() {
+        val maxScroll = 2000
+        val scrollPosition = 5 // At top
+
+        val isScrollable = ReaderToolbarState.isScrollable(maxScroll)
+        val isAtTop = ReaderToolbarState.isAtTop(scrollPosition)
+        val isAtBottom = ReaderToolbarState.isAtBottom(scrollPosition, maxScroll)
+
+        assertTrue("Position 5 should be at top", isAtTop)
+
+        val showToolbar = ReaderToolbarState.shouldShowToolbar(
+            isAutoHideEnabled = true,
+            isScrollable = isScrollable,
+            isAtTop = isAtTop,
+            isAtBottom = isAtBottom,
+            isScrollingDown = false
+        )
+        assertTrue("Toolbar should show at top", showToolbar)
+    }
+}


### PR DESCRIPTION
## Summary

This PR updates reading-page toolbar behavior to better match expected UX around scroll boundaries.

### What changed

- Toolbar should stay visible when page is not scrollable
- Toolbar should show when at top/bottom of a scrollable page
- Toolbar auto-hide behavior in the middle of a scrollable page still follows scroll direction
- Scroll-state handling was cleaned up to make toolbar visibility decisions consistent
- Added unit tests for the toolbar visibility rules

## Testing

- Added unit tests for toolbar visibility policy (`ReaderToolbarStateTest`).
- Manual checks:
  - Long article: toolbar hides on downward scroll in middle, shows on upward scroll
  - Toolbar remains visible at top and bottom boundaries
  - Short/non-scrollable article keeps toolbar visible
