### PR TITLE
fix: toggle read status from existing diff map state

### DIFF
--- a/app/src/main/java/me/ash/reader/domain/data/DiffMapHolder.kt
+++ b/app/src/main/java/me/ash/reader/domain/data/DiffMapHolder.kt
@@ -187,9 +187,16 @@ class DiffMapHolder @Inject constructor(
             return newDiff
         } else {
             if (markRead == null) {
-                // Toggle: remove diff (reverts to original DB state behavior)
-                val removedDiff = diffMap.remove(articleId)
-                return removedDiff?.copy(isRead = !removedDiff.isRead)
+                // Toggle: flip the existing diff's isRead state
+                val toggledIsRead = !diff.isRead
+                if (toggledIsRead == articleWithFeed.article.isRead) {
+                    // Toggling brings us back to the baseline, remove the diff
+                    diffMap.remove(articleId)
+                    return diff.copy(isRead = toggledIsRead)
+                }
+                val updatedDiff = diff.copy(isRead = toggledIsRead)
+                diffMap[articleId] = updatedDiff
+                return updatedDiff
             } else if (diff.isRead != markRead) {
                 // Explicit markRead that differs from current diff.
                 // If it matches the baseline article state, this diff becomes a no-op and should be removed.

--- a/app/src/main/java/me/ash/reader/domain/data/DiffMapHolder.kt
+++ b/app/src/main/java/me/ash/reader/domain/data/DiffMapHolder.kt
@@ -189,13 +189,13 @@ class DiffMapHolder @Inject constructor(
             if (markRead == null) {
                 // Toggle: flip the existing diff's isRead state
                 val toggledIsRead = !diff.isRead
+                val updatedDiff = diff.copy(isRead = toggledIsRead)
                 if (toggledIsRead == articleWithFeed.article.isRead) {
                     // Toggling brings us back to the baseline, remove the diff
                     diffMap.remove(articleId)
-                    return diff.copy(isRead = toggledIsRead)
+                } else {
+                    diffMap[articleId] = updatedDiff
                 }
-                val updatedDiff = diff.copy(isRead = toggledIsRead)
-                diffMap[articleId] = updatedDiff
                 return updatedDiff
             } else if (diff.isRead != markRead) {
                 // Explicit markRead that differs from current diff.

--- a/app/src/test/java/me/ash/reader/domain/data/DiffMapHolderUpdateDiffTest.kt
+++ b/app/src/test/java/me/ash/reader/domain/data/DiffMapHolderUpdateDiffTest.kt
@@ -79,6 +79,48 @@ class DiffMapHolderUpdateDiffTest {
         assertFalse(holder.checkIfRead(article))
     }
 
+    @Test
+    fun `toggle uses current diff state not stale article state`() {
+        // This test reproduces the bug from issue #59:
+        // 1. Article in DB is originally unread (isUnread=true)
+        // 2. User opens article -> auto-marked as read via diffMap
+        // 3. User taps "mark as unread" button in reading page
+        //    - Reading page passes articleWithFeed with MUTATED isUnread=false (from withReadState)
+        //    - This creates a diff with isRead=false
+        // 4. User goes back to flow list
+        // 5. User swipes to toggle
+        //    - Paging list passes articleWithFeed with ORIGINAL isUnread=true (stale DB state)
+        //    - Toggle should use diffMap's state (isRead=false) and toggle to read
+        //    - BUG: Current implementation removes the diff, falling back to stale article.isRead=false
+        val holder = createHolder()
+        val originalUnreadArticle = unreadArticle()
+
+        // Step 2: User opens article, it gets marked as read
+        invokeUpdateDiffInternal(holder, originalUnreadArticle, markRead = true)
+        assertTrue(holder.checkIfRead(originalUnreadArticle))
+
+        // Step 3: User taps "mark as unread" button in reading page
+        // The reading page's articleWithFeed has been mutated by withReadState(true)
+        // so it now has article.isRead = true (article.isUnread = false)
+        val readingPageArticle = originalUnreadArticle.copy(
+            article = originalUnreadArticle.article.copy(isUnread = false)
+        )
+        invokeUpdateDiffInternal(holder, readingPageArticle, markRead = false)
+        assertFalse(holder.checkIfRead(originalUnreadArticle))
+
+        // Step 4-5: User goes back to flow list. 
+        // The paging data still has the stale article with isUnread = true (original DB state),
+        // but diffMap has isRead = false
+
+        // Step 6: User swipes to toggle. The paging list passes the stale article.
+        // Toggle should see that diffMap says "unread" and toggle to "read"
+        invokeUpdateDiffInternal(holder, originalUnreadArticle, markRead = null)
+
+        // The article should now be read (toggled from the diffMap's unread state)
+        assertTrue("After toggle, article should be read (toggled from diffMap unread state)",
+            holder.checkIfRead(originalUnreadArticle))
+    }
+
     private fun createHolder(): DiffMapHolder {
         val context = mock<Context>()
         whenever(context.cacheDir).thenReturn(Files.createTempDirectory("diff-map-holder-test").toFile())


### PR DESCRIPTION
Closes #59

The Bug

  When an article was:
  1. Opened (auto-marked as read)
  2. Manually marked as unread via the reading page button
  3. Returned to the flow list
  4. Swiped to toggle read status

  The article incorrectly remained unread instead of becoming read on the first swipe.

  Root Cause

  In DiffMapHolder.updateDiffInternal, when toggling (markRead = null) with an existing diff, the code removed the diff instead of
  toggling its state:

  // BUG: simply removed the diff
  val removedDiff = diffMap.remove(articleId)
  return removedDiff?.copy(isRead = !removedDiff.isRead)

  This caused the UI to fall back to the stale article.isRead from the paging list (original DB state), which didn't reflect the diff's
  current state.

  The Fix

  Changed the toggle logic to flip the existing diff's isRead state while keeping it in the map:

   app/src/main/java/me/ash/reader/domain/data/DiffMapHolder.kt lines 191-199

                  val toggledIsRead = !diff.isRead
                  if (toggledIsRead == articleWithFeed.article.isRead) {
                      // Toggling brings us back to the baseline, remove the diff
                      diffMap.remove(articleId)
                      return diff.copy(isRead = toggledIsRead)
                  }
                  val updatedDiff = diff.copy(isRead = toggledIsRead)
                  diffMap[articleId] = updatedDiff
                  return updatedDiff

  Verification

  • All unit tests pass including the new test toggle uses current diff state not stale article state which specifically reproduces the
    issue #59 scenario
  • The app builds and launches without crashes
  • Manual emulator testing confirmed the app runs correctly (network issues prevented full feed testing, but the unit tests
    comprehensively cover the fix logic)