### PR TITLE
feat(reading): add link long-press actions

### DIFF
--- a/app/src/main/java/me/ash/reader/ui/component/webview/JavaScriptInterface.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/JavaScriptInterface.kt
@@ -7,6 +7,9 @@ interface JavaScriptInterface {
     @JavascriptInterface
     fun onImgTagClick(imgUrl: String?, alt: String?)
 
+    @JavascriptInterface
+    fun onLinkLongPress(url: String?, text: String?)
+
     companion object {
 
         const val NAME = "JavaScriptInterface"

--- a/app/src/main/java/me/ash/reader/ui/component/webview/LinkActionData.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/LinkActionData.kt
@@ -1,9 +1,17 @@
 package me.ash.reader.ui.component.webview
 
+import java.net.URI
+
 data class LinkActionData(
     val url: String,
     val linkText: String? = null,
 ) {
+    fun fallbackTitle(): String {
+        return runCatching {
+            URI(url).host?.removePrefix("www.")?.takeIf { it.isNotBlank() }
+        }.getOrNull() ?: url
+    }
+
     fun displayUrl(maxLength: Int): String {
         return if (url.length <= maxLength) {
             url

--- a/app/src/main/java/me/ash/reader/ui/component/webview/LinkActionData.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/LinkActionData.kt
@@ -1,0 +1,14 @@
+package me.ash.reader.ui.component.webview
+
+data class LinkActionData(
+    val url: String,
+    val linkText: String? = null,
+) {
+    fun displayUrl(maxLength: Int): String {
+        return if (url.length <= maxLength) {
+            url
+        } else {
+            url.take(maxLength - 1) + "…"
+        }
+    }
+}

--- a/app/src/main/java/me/ash/reader/ui/component/webview/LinkActionDialog.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/LinkActionDialog.kt
@@ -4,6 +4,7 @@ import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
 import android.content.Intent
+import android.os.Build
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -159,7 +160,13 @@ private fun copyToClipboard(context: Context, text: String) {
     val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
     val clip = ClipData.newPlainText("Link", text)
     clipboard.setPrimaryClip(clip)
-    context.showToast(context.getString(R.string.link_copied))
+    if (shouldShowClipboardToast(Build.VERSION.SDK_INT)) {
+        context.showToast(context.getString(R.string.link_copied))
+    }
+}
+
+internal fun shouldShowClipboardToast(sdkInt: Int): Boolean {
+    return sdkInt < Build.VERSION_CODES.TIRAMISU
 }
 
 private fun shareLink(context: Context, url: String) {

--- a/app/src/main/java/me/ash/reader/ui/component/webview/LinkActionDialog.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/LinkActionDialog.kt
@@ -21,6 +21,11 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.vector.ImageVector
@@ -44,6 +49,18 @@ fun LinkActionDialog(
     val context = LocalContext.current
     val openLink = LocalOpenLink.current
     val openLinkSpecificBrowser = LocalOpenLinkSpecificBrowser.current
+    val titleResolverClient = remember { LinkTitleResolver.createClient() }
+    var title by remember(linkData?.url) { mutableStateOf(linkData?.fallbackTitle().orEmpty()) }
+
+    LaunchedEffect(visible, linkData?.url) {
+        val data = linkData
+        if (visible && data != null) {
+            title = data.fallbackTitle()
+            LinkTitleResolver.fetchTitle(data.url, titleResolverClient)?.let { resolvedTitle ->
+                title = resolvedTitle
+            }
+        }
+    }
 
     RYDialog(
         visible = visible && linkData != null,
@@ -56,7 +73,7 @@ fun LinkActionDialog(
         },
         title = {
             Text(
-                text = linkData?.linkText ?: stringResource(R.string.link_action_copy).substringBefore(" "),
+                text = title,
                 maxLines = 2,
                 overflow = TextOverflow.Ellipsis,
             )

--- a/app/src/main/java/me/ash/reader/ui/component/webview/LinkActionDialog.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/LinkActionDialog.kt
@@ -1,0 +1,159 @@
+package me.ash.reader.ui.component.webview
+
+import android.content.ClipData
+import android.content.ClipboardManager
+import android.content.Context
+import android.content.Intent
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.outlined.ContentCopy
+import androidx.compose.material.icons.outlined.Link
+import androidx.compose.material.icons.outlined.OpenInBrowser
+import androidx.compose.material.icons.outlined.Share
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.vector.ImageVector
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextOverflow
+import androidx.compose.ui.unit.dp
+import me.ash.reader.R
+import me.ash.reader.infrastructure.preference.LocalOpenLink
+import me.ash.reader.infrastructure.preference.LocalOpenLinkSpecificBrowser
+import me.ash.reader.ui.component.base.RYDialog
+import me.ash.reader.ui.ext.openURL
+import me.ash.reader.ui.ext.showToast
+
+@Composable
+fun LinkActionDialog(
+    visible: Boolean,
+    linkData: LinkActionData?,
+    onDismissRequest: () -> Unit,
+) {
+    val context = LocalContext.current
+    val openLink = LocalOpenLink.current
+    val openLinkSpecificBrowser = LocalOpenLinkSpecificBrowser.current
+
+    RYDialog(
+        visible = visible && linkData != null,
+        onDismissRequest = onDismissRequest,
+        icon = {
+            Icon(
+                imageVector = Icons.Outlined.Link,
+                contentDescription = null,
+            )
+        },
+        title = {
+            Text(
+                text = linkData?.linkText ?: stringResource(R.string.link_action_copy).substringBefore(" "),
+                maxLines = 2,
+                overflow = TextOverflow.Ellipsis,
+            )
+        },
+        text = {
+            Column(modifier = Modifier.fillMaxWidth()) {
+                Text(
+                    text = linkData?.displayUrl(maxLength = 100) ?: "",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    maxLines = 3,
+                    overflow = TextOverflow.Ellipsis,
+                    modifier = Modifier.padding(bottom = 16.dp),
+                )
+
+                LinkActionItem(
+                    icon = Icons.Outlined.OpenInBrowser,
+                    label = stringResource(R.string.open_in_browser),
+                    onClick = {
+                        onDismissRequest()
+                        linkData?.let {
+                            context.openURL(it.url, openLink, openLinkSpecificBrowser)
+                        }
+                    },
+                )
+
+                LinkActionItem(
+                    icon = Icons.Outlined.ContentCopy,
+                    label = stringResource(R.string.link_action_copy),
+                    onClick = {
+                        onDismissRequest()
+                        linkData?.let {
+                            copyToClipboard(context, it.url)
+                        }
+                    },
+                )
+
+                LinkActionItem(
+                    icon = Icons.Outlined.Share,
+                    label = stringResource(R.string.share),
+                    onClick = {
+                        onDismissRequest()
+                        linkData?.let {
+                            shareLink(context, it.url)
+                        }
+                    },
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismissRequest) {
+                Text(text = stringResource(R.string.cancel))
+            }
+        },
+    )
+}
+
+@Composable
+private fun LinkActionItem(
+    icon: ImageVector,
+    label: String,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Icon(
+            imageVector = icon,
+            contentDescription = label,
+            modifier = Modifier.size(24.dp),
+            tint = MaterialTheme.colorScheme.onSurfaceVariant,
+        )
+        Spacer(modifier = Modifier.width(16.dp))
+        Text(
+            text = label,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.onSurface,
+        )
+    }
+}
+
+private fun copyToClipboard(context: Context, text: String) {
+    val clipboard = context.getSystemService(Context.CLIPBOARD_SERVICE) as ClipboardManager
+    val clip = ClipData.newPlainText("Link", text)
+    clipboard.setPrimaryClip(clip)
+    context.showToast(context.getString(R.string.link_copied))
+}
+
+private fun shareLink(context: Context, url: String) {
+    val intent = Intent(Intent.ACTION_SEND).apply {
+        putExtra(Intent.EXTRA_TEXT, url)
+        type = "text/plain"
+    }
+    context.startActivity(Intent.createChooser(intent, context.getString(R.string.share)))
+}

--- a/app/src/main/java/me/ash/reader/ui/component/webview/LinkActionDialog.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/LinkActionDialog.kt
@@ -20,7 +20,6 @@ import androidx.compose.material.icons.outlined.Share
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -107,11 +106,7 @@ fun LinkActionDialog(
                 )
             }
         },
-        confirmButton = {
-            TextButton(onClick = onDismissRequest) {
-                Text(text = stringResource(R.string.cancel))
-            }
-        },
+        confirmButton = {},
     )
 }
 

--- a/app/src/main/java/me/ash/reader/ui/component/webview/LinkTitleResolver.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/LinkTitleResolver.kt
@@ -1,0 +1,66 @@
+package me.ash.reader.ui.component.webview
+
+import java.io.IOException
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okio.Buffer
+import org.jsoup.Jsoup
+
+object LinkTitleResolver {
+    const val MaxHtmlBytes = 256 * 1024L
+
+    fun createClient(): OkHttpClient {
+        return OkHttpClient.Builder()
+            .connectTimeout(5, TimeUnit.SECONDS)
+            .readTimeout(5, TimeUnit.SECONDS)
+            .followRedirects(true)
+            .build()
+    }
+
+    suspend fun fetchTitle(url: String, client: OkHttpClient): String? = withContext(Dispatchers.IO) {
+        runCatching {
+            val request = Request.Builder()
+                .url(url)
+                .header("Accept", "text/html,application/xhtml+xml")
+                .header("Range", "bytes=0-${MaxHtmlBytes - 1}")
+                .build()
+
+            client.newCall(request).execute().use { response ->
+                if (!response.isSuccessful) return@withContext null
+                val body = response.body ?: return@withContext null
+                extractTitle(readPrefix(body.source(), MaxHtmlBytes))
+            }
+        }.getOrNull()
+    }
+
+    fun extractTitle(html: String): String? {
+        val document = Jsoup.parse(html)
+        return listOf(
+            document.selectFirst("meta[property=og:title]")?.attr("content"),
+            document.selectFirst("meta[name=twitter:title]")?.attr("content"),
+            document.selectFirst("meta[property=twitter:title]")?.attr("content"),
+            document.title(),
+        ).firstNotNullOfOrNull { it?.normalizedTitle() }
+    }
+
+    private fun readPrefix(source: okio.BufferedSource, maxBytes: Long): String {
+        val buffer = Buffer()
+        var remaining = maxBytes
+        while (remaining > 0) {
+            val read = source.read(buffer, minOf(remaining, 8 * 1024L))
+            if (read == -1L) break
+            remaining -= read
+        }
+        if (buffer.size == 0L) throw IOException("No response body")
+        return buffer.readUtf8()
+    }
+
+    private fun String.normalizedTitle(): String? {
+        return trim()
+            .replace(Regex("\\s+"), " ")
+            .takeIf { it.isNotBlank() }
+    }
+}

--- a/app/src/main/java/me/ash/reader/ui/component/webview/RYWebView.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/RYWebView.kt
@@ -89,6 +89,7 @@ fun RYWebView(
     baseUrl: String? = null,
     refererDomain: String? = null,
     onImageClick: ((imgUrl: String, altText: String) -> Unit)? = null,
+    onLinkLongPress: ((url: String, text: String) -> Unit)? = null,
     onShowCustomView: ((View, WebChromeClient.CustomViewCallback) -> Unit)? = null,
     onHideCustomView: (() -> Unit)? = null,
 ) {
@@ -145,6 +146,7 @@ fun RYWebView(
                         ),
                     webChromeClient = webChromeClient,
                     onImageClick = onImageClick,
+                    onLinkLongPress = onLinkLongPress,
                 )
             )
         }

--- a/app/src/main/java/me/ash/reader/ui/component/webview/WebViewClient.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/WebViewClient.kt
@@ -61,6 +61,7 @@ class WebViewClient(
     override fun onPageFinished(view: WebView?, url: String?) {
         super.onPageFinished(view, url)
         view!!.evaluateJavascript(OnImgClickScript, null)
+        view.evaluateJavascript(OnLinkLongPressScript, null)
     }
 
     override fun shouldOverrideUrlLoading(view: WebView?, request: WebResourceRequest?): Boolean {
@@ -105,6 +106,65 @@ class WebViewClient(
                         event.preventDefault();
                         window.${JavaScriptInterface.NAME}.onImgTagClick(this.src, this.alt);
                     }
+                }
+            })()
+            """
+
+        private const val OnLinkLongPressScript = """
+            javascript:(function() {
+                var links = document.getElementsByTagName("a");
+                var longPressTimer = null;
+                var longPressDuration = 500;
+                var touchStartX = 0;
+                var touchStartY = 0;
+                var moveThreshold = 10;
+
+                for(var i = 0; i < links.length; i++){
+                    (function(link) {
+                        link.addEventListener('touchstart', function(event) {
+                            touchStartX = event.touches[0].clientX;
+                            touchStartY = event.touches[0].clientY;
+                            longPressTimer = setTimeout(function() {
+                                event.preventDefault();
+                                event.stopPropagation();
+                                var href = link.href || '';
+                                var text = link.innerText || link.textContent || '';
+                                window.${JavaScriptInterface.NAME}.onLinkLongPress(href, text.trim());
+                            }, longPressDuration);
+                        }, {passive: false});
+
+                        link.addEventListener('touchmove', function(event) {
+                            if (longPressTimer) {
+                                var dx = Math.abs(event.touches[0].clientX - touchStartX);
+                                var dy = Math.abs(event.touches[0].clientY - touchStartY);
+                                if (dx > moveThreshold || dy > moveThreshold) {
+                                    clearTimeout(longPressTimer);
+                                    longPressTimer = null;
+                                }
+                            }
+                        });
+
+                        link.addEventListener('touchend', function(event) {
+                            if (longPressTimer) {
+                                clearTimeout(longPressTimer);
+                                longPressTimer = null;
+                            }
+                        });
+
+                        link.addEventListener('touchcancel', function(event) {
+                            if (longPressTimer) {
+                                clearTimeout(longPressTimer);
+                                longPressTimer = null;
+                            }
+                        });
+
+                        link.addEventListener('contextmenu', function(event) {
+                            event.preventDefault();
+                            var href = link.href || '';
+                            var text = link.innerText || link.textContent || '';
+                            window.${JavaScriptInterface.NAME}.onLinkLongPress(href, text.trim());
+                        });
+                    })(links[i]);
                 }
             })()
             """

--- a/app/src/main/java/me/ash/reader/ui/component/webview/WebViewClient.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/WebViewClient.kt
@@ -118,6 +118,7 @@ class WebViewClient(
                 var touchStartX = 0;
                 var touchStartY = 0;
                 var moveThreshold = 10;
+                var suppressNextClick = false;
 
                 for(var i = 0; i < links.length; i++){
                     (function(link) {
@@ -125,8 +126,7 @@ class WebViewClient(
                             touchStartX = event.touches[0].clientX;
                             touchStartY = event.touches[0].clientY;
                             longPressTimer = setTimeout(function() {
-                                event.preventDefault();
-                                event.stopPropagation();
+                                suppressNextClick = true;
                                 var href = link.href || '';
                                 var text = link.innerText || link.textContent || '';
                                 window.${JavaScriptInterface.NAME}.onLinkLongPress(href, text.trim());
@@ -164,6 +164,14 @@ class WebViewClient(
                             var text = link.innerText || link.textContent || '';
                             window.${JavaScriptInterface.NAME}.onLinkLongPress(href, text.trim());
                         });
+
+                        link.addEventListener('click', function(event) {
+                            if (suppressNextClick) {
+                                event.preventDefault();
+                                event.stopPropagation();
+                                suppressNextClick = false;
+                            }
+                        }, true);
                     })(links[i]);
                 }
             })()

--- a/app/src/main/java/me/ash/reader/ui/component/webview/WebViewLayout.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/WebViewLayout.kt
@@ -16,6 +16,7 @@ object WebViewLayout {
         webViewClient: WebViewClient,
         webChromeClient: RYWebChromeClient? = null,
         onImageClick: ((imgUrl: String, altText: String) -> Unit)? = null,
+        onLinkLongPress: ((url: String, text: String) -> Unit)? = null,
     ): HorizontalScrollAwareWebView {
         Log.d("WebViewLayout", "Creating WebView with webChromeClient=$webChromeClient")
         return HorizontalScrollAwareWebView(context).apply {
@@ -57,6 +58,13 @@ object WebViewLayout {
                         override fun onImgTagClick(imgUrl: String?, alt: String?) {
                             if (onImageClick != null && imgUrl != null) {
                                 onImageClick.invoke(imgUrl, alt ?: "")
+                            }
+                        }
+
+                        @JavascriptInterface
+                        override fun onLinkLongPress(url: String?, text: String?) {
+                            if (onLinkLongPress != null && url != null) {
+                                onLinkLongPress.invoke(url, text ?: "")
                             }
                         }
                     },

--- a/app/src/main/java/me/ash/reader/ui/page/home/reading/Content.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/reading/Content.kt
@@ -41,6 +41,7 @@ fun Content(
     isLoading: Boolean,
     contentPadding: PaddingValues = PaddingValues(),
     onImageClick: ((imgUrl: String, altText: String) -> Unit)? = null,
+    onLinkLongPress: ((url: String, text: String) -> Unit)? = null,
     onShowCustomView: ((View, WebChromeClient.CustomViewCallback) -> Unit)? = null,
     onHideCustomView: (() -> Unit)? = null,
 ) {
@@ -84,6 +85,7 @@ fun Content(
                     baseUrl = link,
                     refererDomain = link.extractDomain(),
                     onImageClick = onImageClick,
+                    onLinkLongPress = onLinkLongPress,
                     onShowCustomView = onShowCustomView,
                     onHideCustomView = onHideCustomView,
                 )

--- a/app/src/main/java/me/ash/reader/ui/page/home/reading/ReadingPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/reading/ReadingPage.kt
@@ -48,6 +48,8 @@ import android.widget.FrameLayout
 import kotlin.math.abs
 import kotlinx.coroutines.launch
 import me.ash.reader.R
+import me.ash.reader.ui.component.webview.LinkActionDialog
+import me.ash.reader.ui.component.webview.LinkActionData
 import me.ash.reader.infrastructure.android.TextToSpeechManager
 import me.ash.reader.infrastructure.preference.LocalPullToSwitchArticle
 import me.ash.reader.infrastructure.preference.LocalReadingAutoHideToolbar
@@ -88,6 +90,10 @@ fun ReadingPage(
     var fullscreenVideoCallback by remember { mutableStateOf<WebChromeClient.CustomViewCallback?>(null) }
     val isVideoFullscreen = fullscreenVideoView != null
 
+    // Link action dialog state
+    var showLinkActionDialog by remember { mutableStateOf(false) }
+    var linkActionData by remember { mutableStateOf<LinkActionData?>(null) }
+
     // Handle back press when video is fullscreen
     BackHandler(enabled = isVideoFullscreen) {
         fullscreenVideoCallback?.onCustomViewHidden()
@@ -109,6 +115,12 @@ fun ReadingPage(
     //    }
 
     var bringToTop by remember { mutableStateOf(false) }
+
+    LinkActionDialog(
+        visible = showLinkActionDialog,
+        linkData = linkActionData,
+        onDismissRequest = { showLinkActionDialog = false },
+    )
 
     Box(modifier = Modifier.fillMaxSize()) {
         Scaffold(
@@ -264,6 +276,13 @@ fun ReadingPage(
                                             onImageClick = { imgUrl, altText ->
                                                 currentImageData = ImageData(imgUrl, altText)
                                                 showFullScreenImageViewer = true
+                                            },
+                                            onLinkLongPress = { url, text ->
+                                                linkActionData = LinkActionData(
+                                                    url = url,
+                                                    linkText = text.ifEmpty { null },
+                                                )
+                                                showLinkActionDialog = true
                                             },
                                             onShowCustomView = { view, callback ->
                                                 android.util.Log.d("ReadingPage", "onShowCustomView lambda called with view=$view")

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -384,4 +384,6 @@
     <string name="disable">Disable</string>
     <string name="server_unreachable">Server unreachable. Check your network connection and server URL.</string>
     <string name="unauthorized">Invalid credentials</string>
+    <string name="link_action_copy">Copy link</string>
+    <string name="link_copied">Link copied</string>
 </resources>

--- a/app/src/test/java/me/ash/reader/ui/component/webview/LinkActionDataTest.kt
+++ b/app/src/test/java/me/ash/reader/ui/component/webview/LinkActionDataTest.kt
@@ -1,0 +1,61 @@
+package me.ash.reader.ui.component.webview
+
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class LinkActionDataTest {
+
+    @Test
+    fun `displayUrl returns full url when under maxLength`() {
+        val data = LinkActionData("https://example.com")
+        assertEquals("https://example.com", data.displayUrl(maxLength = 50))
+    }
+
+    @Test
+    fun `displayUrl truncates long url with ellipsis`() {
+        val data = LinkActionData("https://example.com/very/long/path/to/some/resource/page.html")
+        val result = data.displayUrl(maxLength = 30)
+        assertEquals(30, result.length)
+        assert(result.endsWith("…"))
+    }
+
+    @Test
+    fun `displayUrl handles exact maxLength`() {
+        val data = LinkActionData("https://example.com")
+        assertEquals("https://example.com", data.displayUrl(maxLength = 19))
+    }
+
+    @Test
+    fun `displayUrl handles one over maxLength`() {
+        val data = LinkActionData("https://example.com/")
+        val result = data.displayUrl(maxLength = 19)
+        assertEquals(19, result.length)
+        assert(result.endsWith("…"))
+    }
+
+    @Test
+    fun `displayUrl handles empty url`() {
+        val data = LinkActionData("")
+        assertEquals("", data.displayUrl(maxLength = 50))
+    }
+
+    @Test
+    fun `displayUrl handles very short maxLength`() {
+        val data = LinkActionData("https://example.com")
+        val result = data.displayUrl(maxLength = 5)
+        assertEquals(5, result.length)
+        assertEquals("http…", result)
+    }
+
+    @Test
+    fun `displayUrl with linkText shows linkText`() {
+        val data = LinkActionData("https://example.com", "Click Here")
+        assertEquals("Click Here", data.linkText)
+    }
+
+    @Test
+    fun `default linkText is null`() {
+        val data = LinkActionData("https://example.com")
+        assertEquals(null, data.linkText)
+    }
+}

--- a/app/src/test/java/me/ash/reader/ui/component/webview/LinkActionDataTest.kt
+++ b/app/src/test/java/me/ash/reader/ui/component/webview/LinkActionDataTest.kt
@@ -58,4 +58,16 @@ class LinkActionDataTest {
         val data = LinkActionData("https://example.com")
         assertEquals(null, data.linkText)
     }
+
+    @Test
+    fun `fallbackTitle returns hostname without www`() {
+        val data = LinkActionData("https://www.example.com/item?id=1")
+        assertEquals("example.com", data.fallbackTitle())
+    }
+
+    @Test
+    fun `fallbackTitle returns url when hostname is unavailable`() {
+        val data = LinkActionData("not a url")
+        assertEquals("not a url", data.fallbackTitle())
+    }
 }

--- a/app/src/test/java/me/ash/reader/ui/component/webview/LinkActionDialogTest.kt
+++ b/app/src/test/java/me/ash/reader/ui/component/webview/LinkActionDialogTest.kt
@@ -1,0 +1,23 @@
+package me.ash.reader.ui.component.webview
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class LinkActionDialogTest {
+
+    @Test
+    fun `shouldShowClipboardToast returns true before Android 13`() {
+        assertTrue(shouldShowClipboardToast(32))
+    }
+
+    @Test
+    fun `shouldShowClipboardToast returns false on Android 13`() {
+        assertFalse(shouldShowClipboardToast(33))
+    }
+
+    @Test
+    fun `shouldShowClipboardToast returns false after Android 13`() {
+        assertFalse(shouldShowClipboardToast(34))
+    }
+}

--- a/app/src/test/java/me/ash/reader/ui/component/webview/LinkTitleResolverTest.kt
+++ b/app/src/test/java/me/ash/reader/ui/component/webview/LinkTitleResolverTest.kt
@@ -1,0 +1,57 @@
+package me.ash.reader.ui.component.webview
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
+import org.junit.Test
+
+class LinkTitleResolverTest {
+
+    @Test
+    fun `extractTitle prefers og title`() {
+        val html = """
+            <html>
+              <head>
+                <meta property="og:title" content="Open Graph Title">
+                <meta name="twitter:title" content="Twitter Title">
+                <title>Document Title</title>
+              </head>
+            </html>
+        """
+
+        assertEquals("Open Graph Title", LinkTitleResolver.extractTitle(html))
+    }
+
+    @Test
+    fun `extractTitle falls back to twitter title`() {
+        val html = """
+            <html>
+              <head>
+                <meta name="twitter:title" content="Twitter Title">
+                <title>Document Title</title>
+              </head>
+            </html>
+        """
+
+        assertEquals("Twitter Title", LinkTitleResolver.extractTitle(html))
+    }
+
+    @Test
+    fun `extractTitle falls back to document title`() {
+        val html = "<html><head><title>Document Title</title></head></html>"
+
+        assertEquals("Document Title", LinkTitleResolver.extractTitle(html))
+    }
+
+    @Test
+    fun `extractTitle normalizes whitespace`() {
+        val html = """<meta property="og:title" content="  One
+            Two   Three  ">"""
+
+        assertEquals("One Two Three", LinkTitleResolver.extractTitle(html))
+    }
+
+    @Test
+    fun `extractTitle returns null when no title is available`() {
+        assertNull(LinkTitleResolver.extractTitle("<html><head></head><body></body></html>"))
+    }
+}


### PR DESCRIPTION
## Summary

- Add long-press handling for links in the reader WebView.
- Show a centered link action dialog with Open in browser, Copy link, and Share actions.
- Resolve the dialog title from page metadata so URL links do not render as duplicate title/subtitle text.
- Avoid showing an in-app copy toast on Android 13+ because the system already shows clipboard feedback.

## Screenshot

<img height="400" alt="image" src="https://github.com/user-attachments/assets/97c40783-0c2e-4622-98a8-5f38b9d0cfe0" />


## Validation

- `./gradlew :app:testGithubDebugUnitTest --tests 'me.ash.reader.ui.component.webview.*'`
- Installed `ReadYou-0.16.1-6ec286c1.apk` on API 35 emulator.
- Verified long-press link dialog resolves a GitHub issue title, has no Cancel button, dismisses on outside tap, and copy does not show the app toast on Android 13+.

Closes #60
