### PR TITLE
[codex] Fix reading title link tap

### DIFF
--- a/app/src/androidTest/java/me/ash/reader/ui/page/home/reading/MetadataTest.kt
+++ b/app/src/androidTest/java/me/ash/reader/ui/page/home/reading/MetadataTest.kt
@@ -1,0 +1,42 @@
+package me.ash.reader.ui.page.home.reading
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.ui.test.assertHasClickAction
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onNodeWithText
+import androidx.compose.ui.test.performClick
+import java.util.Date
+import org.junit.Assert.assertEquals
+import org.junit.Rule
+import org.junit.Test
+
+class MetadataTest {
+
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @Test
+    fun titleClickOpensArticleLink() {
+        val title = "Example article"
+        val link = "https://example.com/article"
+        var openedLink: String? = null
+
+        composeRule.setContent {
+            MaterialTheme {
+                Metadata(
+                    feedName = "Example feed",
+                    title = title,
+                    publishedDate = Date(0),
+                    link = link,
+                    onTitleClick = { openedLink = it },
+                )
+            }
+        }
+
+        composeRule.onNodeWithText(title)
+            .assertHasClickAction()
+            .performClick()
+
+        assertEquals(link, openedLink)
+    }
+}

--- a/app/src/main/java/me/ash/reader/ui/page/home/reading/Content.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/reading/Content.kt
@@ -58,6 +58,8 @@ fun Content(
                         title = title,
                         author = author,
                         publishedDate = publishedDate,
+                        link = link,
+                        onTitleClick = { uriHandler.openUri(it) },
                     )
                 }
             }

--- a/app/src/main/java/me/ash/reader/ui/page/home/reading/Content.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/reading/Content.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3ExpressiveApi
 import androidx.compose.material3.LoadingIndicator
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalUriHandler
@@ -48,6 +49,9 @@ fun Content(
     val textContentWidth = LocalTextContentWidth.current
     val maxWidthModifier = Modifier.widthIn(max = textContentWidth)
     val uriHandler = LocalUriHandler.current
+    val openTitleLink = remember(uriHandler) {
+        { uri: String -> uriHandler.openUri(uri) }
+    }
 
     val headline =
         @Composable {
@@ -59,7 +63,7 @@ fun Content(
                         author = author,
                         publishedDate = publishedDate,
                         link = link,
-                        onTitleClick = { uriHandler.openUri(it) },
+                        onTitleClick = openTitleLink,
                     )
                 }
             }

--- a/app/src/main/java/me/ash/reader/ui/page/home/reading/Metadata.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/reading/Metadata.kt
@@ -1,5 +1,6 @@
 package me.ash.reader.ui.page.home.reading
 
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -33,6 +34,8 @@ fun Metadata(
     publishedDate: Date,
     modifier: Modifier = Modifier,
     author: String? = null,
+    link: String? = null,
+    onTitleClick: ((String) -> Unit)? = null,
 ) {
     val context = LocalContext.current
     val titleBold = LocalReadingTitleBold.current
@@ -60,8 +63,13 @@ fun Metadata(
             textAlign = titleAlign,
         )
         Spacer(modifier = Modifier.height(4.dp))
+        val titleModifier = if (!link.isNullOrBlank() && onTitleClick != null) {
+            Modifier.fillMaxWidth().clickable { onTitleClick(link) }
+        } else {
+            Modifier.fillMaxWidth()
+        }
         Text(
-            modifier = Modifier.fillMaxWidth(),
+            modifier = titleModifier,
             text = if (titleUpperCase.value) titleUpperCaseString else title,
             color = MaterialTheme.colorScheme.onSurface,
             style =

--- a/app/src/main/java/me/ash/reader/ui/page/home/reading/Metadata.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/reading/Metadata.kt
@@ -14,9 +14,12 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.semantics.Role
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
+import me.ash.reader.R
 import me.ash.reader.infrastructure.preference.LocalReadingFonts
 import me.ash.reader.infrastructure.preference.LocalReadingTitleAlign
 import me.ash.reader.infrastructure.preference.LocalReadingTitleBold
@@ -44,6 +47,7 @@ fun Metadata(
     val dateString =
         remember(publishedDate) { publishedDate.formatAsString(context, atHourMinute = true) }
     val fontFamily = LocalReadingFonts.current.asFontFamily(context)
+    val openArticleLinkLabel = stringResource(R.string.open_article_link)
 
     val titleUpperCaseString by remember { derivedStateOf { title.uppercase() } }
 
@@ -64,7 +68,14 @@ fun Metadata(
         )
         Spacer(modifier = Modifier.height(4.dp))
         val titleModifier = if (!link.isNullOrBlank() && onTitleClick != null) {
-            Modifier.fillMaxWidth().clickable { onTitleClick(link) }
+            Modifier
+                .fillMaxWidth()
+                .clickable(
+                    onClickLabel = openArticleLinkLabel,
+                    role = Role.Button,
+                ) {
+                    onTitleClick(link)
+                }
         } else {
             Modifier.fillMaxWidth()
         }

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -53,6 +53,7 @@
     <string name="all_parse_full_content_toast">Full content parsing of all articles in the \"%1$s\" group is allowed</string>
     <string name="all_deny_parse_full_content_toast">Full content parsing of all articles in the \"%1$s\" group is denied</string>
     <string name="open_in_browser">Open in browser</string>
+    <string name="open_article_link">Open article link</string>
     <string name="all_open_in_browser_tips">Open all articles in the \"%1$s\" group using the default browser</string>
     <string name="all_open_in_browser_toast">Opening all articles in the \"%1$s\" group in the default browser is allowed</string>
     <string name="all_deny_open_in_browser_toast">Opening all articles in the \"%1$s\" group in the default browser is denied</string>


### PR DESCRIPTION
## Summary
- Adds a Compose regression test for tapping the reading page title.
- Restores title tap behavior by opening the article link through `LocalUriHandler`.

## Root Cause
The reading page rendered article metadata without wiring the article link into the title, so tapping the title no longer opened the original article.

## Impact
Users can once again tap the title on the reading page to open the article source link.

## Validation
- Confirmed the new regression test failed before the fix during `:app:compileGithubDebugAndroidTestKotlin` because `Metadata` did not expose link click parameters.
- Ran `./gradlew :app:compileGithubDebugAndroidTestKotlin` successfully after applying the fix.

Closes #65