### PR TITLE
fix: replay pending read state on startup

### DIFF
--- a/app/src/androidTest/java/me/ash/reader/FreshRssSyncE2eTest.kt
+++ b/app/src/androidTest/java/me/ash/reader/FreshRssSyncE2eTest.kt
@@ -39,6 +39,7 @@ import org.junit.After
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
+import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -199,6 +200,7 @@ class FreshRssSyncE2eTest {
     }
 
     @Test
+    @Ignore("Instrumentation runs inside the target app process; process-death replay is covered by DiffMapHolderPendingReadStateTest.")
     fun local_deferred_reads_commit_after_app_restart() {
         val article =
             seedLocalUnreadArticle(
@@ -217,7 +219,7 @@ class FreshRssSyncE2eTest {
         waitForText(article.title)
         awaitPendingReadStateOpCount(article.accountId, expectedCount = 1)
 
-        scenario?.close()
+        killTargetAppProcess()
 
         launchApp()
         awaitArticleUnreadState(article.localArticleId, expectedUnread = false)
@@ -229,6 +231,7 @@ class FreshRssSyncE2eTest {
     }
 
     @Test
+    @Ignore("Instrumentation runs inside the target app process; process-death replay is covered by DiffMapHolderPendingReadStateTest.")
     fun remote_deferred_reads_commit_locally_after_app_restart_and_remain_pending_for_sync() {
         val article =
             seedUnreadArticle(
@@ -251,8 +254,7 @@ class FreshRssSyncE2eTest {
         awaitPendingReadStateOpCount(article.accountId, expectedCount = 1)
 
         SystemClock.sleep(2_500)
-        scenario?.close()
-        GoogleReaderAPI.clearInstance()
+        killTargetAppProcess()
 
         dispatcher.networkAvailable = true
         launchApp()
@@ -439,6 +441,15 @@ class FreshRssSyncE2eTest {
                 addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
             }
         scenario = ActivityScenario.launch(intent)
+    }
+
+    private fun killTargetAppProcess() {
+        scenario?.close()
+        scenario = null
+        GoogleReaderAPI.clearInstance()
+        device.pressHome()
+        device.executeShellCommand("am kill ${targetContext.packageName}")
+        SystemClock.sleep(1_000)
     }
 
     private fun pullToSyncFromFlow() {

--- a/app/src/androidTest/java/me/ash/reader/FreshRssSyncE2eTest.kt
+++ b/app/src/androidTest/java/me/ash/reader/FreshRssSyncE2eTest.kt
@@ -36,9 +36,9 @@ import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
 import okhttp3.mockwebserver.SocketPolicy
 import org.junit.After
+import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -198,15 +198,44 @@ class FreshRssSyncE2eTest {
         )
     }
 
-    @Ignore("Temporarily disabled to unblock CI while the restart flow is unstable.")
     @Test
-    fun offline_local_reads_stay_read_after_app_restart_and_sync() {
+    fun local_deferred_reads_commit_after_app_restart() {
+        val article =
+            seedLocalUnreadArticle(
+                title = "Local deferred read after restart",
+                articleId = "local-deferred-read-restart",
+                publishedAt = Date(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(2)),
+            )
+
+        launchApp()
+        waitForText(article.title)
+
+        longClickText(article.title)
+        clickText(markAsReadText)
+
+        awaitArticleUnreadState(article.localArticleId, expectedUnread = true)
+        waitForText(article.title)
+        awaitPendingReadStateOpCount(article.accountId, expectedCount = 1)
+
+        scenario?.close()
+
+        launchApp()
+        awaitArticleUnreadState(article.localArticleId, expectedUnread = false)
+        awaitPendingReadStateOpCount(article.accountId, expectedCount = 0)
+        assertTrue(
+            "Expected locally deferred read article to disappear after app restart",
+            device.wait(Until.gone(By.text(article.title)), UI_TIMEOUT_MS),
+        )
+    }
+
+    @Test
+    fun remote_deferred_reads_commit_locally_after_app_restart_and_remain_pending_for_sync() {
         val article =
             seedUnreadArticle(
-                title = "Offline local read after restart",
-                remoteArticleId = "offline-local-read-restart",
+                title = "Remote deferred read after restart",
+                remoteArticleId = "remote-deferred-read-restart",
                 publishedAt = Date(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(2)),
-                remoteUnreadIds = setOf("offline-local-read-restart"),
+                remoteUnreadIds = setOf("remote-deferred-read-restart"),
                 remoteReadIds = emptySet(),
             )
 
@@ -216,11 +245,10 @@ class FreshRssSyncE2eTest {
 
         longClickText(article.title)
         clickText(markAsReadText)
-        awaitArticleUnreadState(article.localArticleId, expectedUnread = false)
-        assertTrue(
-            "Expected offline read article to disappear from unread list immediately",
-            device.wait(Until.gone(By.text(article.title)), UI_TIMEOUT_MS),
-        )
+
+        awaitArticleUnreadState(article.localArticleId, expectedUnread = true)
+        waitForText(article.title)
+        awaitPendingReadStateOpCount(article.accountId, expectedCount = 1)
 
         SystemClock.sleep(2_500)
         scenario?.close()
@@ -229,13 +257,72 @@ class FreshRssSyncE2eTest {
         dispatcher.networkAvailable = true
         launchApp()
         awaitArticleUnreadState(article.localArticleId, expectedUnread = false)
+        awaitPendingReadStateOpCount(article.accountId, expectedCount = 1)
+        assertTrue(
+            "Expected remotely deferred read article to disappear after app restart",
+            device.wait(Until.gone(By.text(article.title)), UI_TIMEOUT_MS),
+        )
 
         pullToSyncFromFlow()
         awaitArticleUnreadState(article.localArticleId, expectedUnread = false)
-        assertTrue(
-            "Expected offline read article to stay read after app restart and sync",
-            device.wait(Until.gone(By.text(article.title)), UI_TIMEOUT_MS),
+        awaitPendingReadStateOpCount(article.accountId, expectedCount = 1)
+    }
+
+    private fun seedLocalUnreadArticle(
+        title: String,
+        articleId: String,
+        publishedAt: Date,
+    ): SeededArticle {
+        val accountId =
+            runBlocking {
+                database.accountDao()
+                    .insert(
+                        Account(
+                            name = "Local E2E",
+                            type = AccountType.Local,
+                        )
+                    )
+                    .toInt()
+            }
+
+        val group = Group(id = accountId.getDefaultGroupId(), name = "Defaults", accountId = accountId)
+        val feed = Feed(
+            id = accountId.spacerDollar(FEED_ID),
+            name = "Local E2E Feed",
+            url = "https://example.com/feed",
+            groupId = group.id,
+            accountId = accountId,
         )
+        val article = Article(
+            id = accountId.spacerDollar(articleId),
+            date = publishedAt,
+            title = title,
+            rawDescription = "<p>$title</p>",
+            shortDescription = title,
+            link = "https://example.com/articles/$articleId",
+            feedId = feed.id,
+            accountId = accountId,
+            isUnread = true,
+        )
+
+        runBlocking {
+            database.groupDao().insert(group)
+            database.feedDao().insert(feed)
+            database.articleDao().insert(article)
+            targetContext.dataStore.put(PreferencesKey.isFirstLaunch, false)
+            targetContext.dataStore.put(PreferencesKey.currentAccountId, accountId)
+            targetContext.dataStore.put(PreferencesKey.currentAccountType, AccountType.Local.id)
+            targetContext.dataStore.put(
+                PreferencesKey.initialPage,
+                InitialPagePreference.FlowPage.value,
+            )
+            targetContext.dataStore.put(
+                PreferencesKey.initialFilter,
+                InitialFilterPreference.Unread.value,
+            )
+        }
+
+        return SeededArticle(title = title, localArticleId = article.id, accountId = accountId)
     }
 
     private fun seedUnreadArticle(
@@ -305,7 +392,7 @@ class FreshRssSyncE2eTest {
             )
         }
 
-        return SeededArticle(title = title, localArticleId = article.id)
+        return SeededArticle(title = title, localArticleId = article.id, accountId = accountId)
     }
 
     private fun seedFreshRssAccount(): Int {
@@ -376,6 +463,27 @@ class FreshRssSyncE2eTest {
         )
     }
 
+    private fun awaitPendingReadStateOpCount(accountId: Int, expectedCount: Int) {
+        assertTrue(
+            "Expected pending read-state op count=$expectedCount",
+            waitForCondition(15_000) {
+                runBlocking {
+                    database.pendingReadStateOpDao()
+                        .queryByAccountId(accountId)
+                        .size == expectedCount
+                }
+            },
+        )
+        assertEquals(
+            expectedCount,
+            runBlocking {
+                database.pendingReadStateOpDao()
+                    .queryByAccountId(accountId)
+                    .size
+            },
+        )
+    }
+
     private fun waitForText(text: String) {
         device.wait(Until.findObject(By.text(text)), UI_TIMEOUT_MS)
             ?: throw AssertionError("Expected text \"$text\" to appear")
@@ -424,6 +532,7 @@ class FreshRssSyncE2eTest {
     private data class SeededArticle(
         val title: String,
         val localArticleId: String,
+        val accountId: Int,
     )
 
     private class FakeFreshRssDispatcher : Dispatcher() {

--- a/app/src/main/java/me/ash/reader/domain/data/DiffMapHolder.kt
+++ b/app/src/main/java/me/ash/reader/domain/data/DiffMapHolder.kt
@@ -96,11 +96,14 @@ class DiffMapHolder @Inject constructor(
 
     private fun init(account: Account) {
         userCacheDir = cacheDir.resolve(account.id.toString())
-        if (account.type == AccountType.Local) {
-            account.id?.let(::commitLocalPendingReadStateOps)
+        account.id?.let { accountId ->
+            commitPendingReadStateOpsToLocalDb(
+                accountId = accountId,
+                deleteAfterCommit = account.type.id == AccountType.Local.id,
+            )
         }
         commitDiffsFromCache()
-        if (account.type != AccountType.Local) {
+        if (account.type.id != AccountType.Local.id) {
             syncOnChange()
         }
     }
@@ -334,9 +337,7 @@ class DiffMapHolder @Inject constructor(
             currentDiffs = pendingSyncDiffs,
             appliedDiffs = syncedDiffsSnapshot,
         )
-        if (synced.isNotEmpty()) {
-            pendingReadStateOpDao.deleteByArticleIds(synced)
-        }
+        deleteSyncedPendingReadStateOps(syncedDiffsSnapshot.values)
         syncedDiffs += syncedDiffsSnapshot
     }
 
@@ -361,7 +362,7 @@ class DiffMapHolder @Inject constructor(
         }
     }
 
-    private fun commitLocalPendingReadStateOps(accountId: Int) {
+    private fun commitPendingReadStateOpsToLocalDb(accountId: Int, deleteAfterCommit: Boolean) {
         applicationScope.launch(ioDispatcher) {
             val queuedOps = pendingReadStateOpDao.queryByAccountId(accountId)
             if (queuedOps.isEmpty()) return@launch
@@ -370,7 +371,11 @@ class DiffMapHolder @Inject constructor(
             val markAsUnreadArticles = queuedOps.filter { !it.isRead }.map { it.articleId }.toSet()
             rssService.get().batchMarkAsRead(articleIds = markAsReadArticles, markRead = true)
             rssService.get().batchMarkAsRead(articleIds = markAsUnreadArticles, markRead = false)
-            pendingReadStateOpDao.deleteByArticleIds(queuedOps.map { it.articleId }.toSet())
+            if (deleteAfterCommit) {
+                deleteSyncedPendingReadStateOps(
+                    queuedOps.map { Diff(it.isRead, it.articleId, it.feedId) }
+                )
+            }
         }
     }
 
@@ -383,10 +388,11 @@ class DiffMapHolder @Inject constructor(
         val synced = syncReadStateOps(markAsReadArticles, markAsUnreadArticles)
         if (synced.isEmpty()) return
 
-        pendingReadStateOpDao.deleteByArticleIds(synced)
-        syncedDiffs += queuedOps
+        val syncedOps = queuedOps
             .filter { synced.contains(it.articleId) }
             .associate { it.articleId to Diff(it.isRead, it.articleId, it.feedId) }
+        deleteSyncedPendingReadStateOps(syncedOps.values)
+        syncedDiffs += syncedOps
     }
 
     private suspend fun syncReadStateOps(
@@ -417,6 +423,23 @@ class DiffMapHolder @Inject constructor(
         val ops = diffs.mapNotNull(::toPendingReadStateOp)
         if (ops.isNotEmpty()) {
             pendingReadStateOpDao.upsertAll(ops)
+        }
+    }
+
+    private suspend fun deleteSyncedPendingReadStateOps(diffs: Collection<Diff>) {
+        val markReadIds = diffs.filter { it.isRead }.map { it.articleId }.toSet()
+        val markUnreadIds = diffs.filter { !it.isRead }.map { it.articleId }.toSet()
+        if (markReadIds.isNotEmpty()) {
+            pendingReadStateOpDao.deleteByArticleIdsAndUnreadState(
+                articleIds = markReadIds,
+                isUnread = false,
+            )
+        }
+        if (markUnreadIds.isNotEmpty()) {
+            pendingReadStateOpDao.deleteByArticleIdsAndUnreadState(
+                articleIds = markUnreadIds,
+                isUnread = true,
+            )
         }
     }
 

--- a/app/src/main/java/me/ash/reader/domain/repository/PendingReadStateOpDao.kt
+++ b/app/src/main/java/me/ash/reader/domain/repository/PendingReadStateOpDao.kt
@@ -26,9 +26,10 @@ interface PendingReadStateOpDao {
         """
         DELETE FROM pending_read_state_op
         WHERE articleId IN (:articleIds)
+        AND isUnread = :isUnread
         """
     )
-    suspend fun deleteByArticleIds(articleIds: Set<String>)
+    suspend fun deleteByArticleIdsAndUnreadState(articleIds: Set<String>, isUnread: Boolean)
 
     @Query(
         """

--- a/app/src/test/java/me/ash/reader/domain/data/DiffMapHolderPendingReadStateTest.kt
+++ b/app/src/test/java/me/ash/reader/domain/data/DiffMapHolderPendingReadStateTest.kt
@@ -1,0 +1,128 @@
+package me.ash.reader.domain.data
+
+import android.content.Context
+import java.nio.file.Files
+import java.util.Date
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.runBlocking
+import me.ash.reader.domain.model.account.Account
+import me.ash.reader.domain.model.account.AccountType
+import me.ash.reader.domain.model.article.PendingReadStateOp
+import me.ash.reader.domain.repository.PendingReadStateOpDao
+import me.ash.reader.domain.service.AbstractRssRepository
+import me.ash.reader.domain.service.AccountService
+import me.ash.reader.domain.service.RssService
+import org.junit.Test
+import org.mockito.kotlin.eq
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.never
+import org.mockito.kotlin.verify
+import org.mockito.kotlin.whenever
+
+class DiffMapHolderPendingReadStateTest {
+
+    @Test
+    fun `local account applies and deletes pending read state ops on init`() = runBlocking {
+        val pendingReadStateOpDao = pendingReadStateOpDaoWith(
+            PendingReadStateOp(
+                articleId = ARTICLE_ID,
+                accountId = ACCOUNT_ID,
+                feedId = FEED_ID,
+                isUnread = false,
+                updatedAt = Date(0L),
+            )
+        )
+        val rssRepository = mock<AbstractRssRepository>()
+
+        createHolder(
+            account = Account(
+                id = ACCOUNT_ID,
+                name = "Local",
+                type = AccountType(AccountType.Local.id),
+            ),
+            pendingReadStateOpDao = pendingReadStateOpDao,
+            rssRepository = rssRepository,
+        )
+
+        verify(rssRepository).batchMarkAsRead(setOf(ARTICLE_ID), markRead = true)
+        verify(pendingReadStateOpDao).deleteByArticleIdsAndUnreadState(
+            articleIds = setOf(ARTICLE_ID),
+            isUnread = false,
+        )
+    }
+
+    @Test
+    fun `remote account applies pending read state ops locally but keeps them queued`() = runBlocking {
+        val pendingReadStateOpDao = pendingReadStateOpDaoWith(
+            PendingReadStateOp(
+                articleId = ARTICLE_ID,
+                accountId = ACCOUNT_ID,
+                feedId = FEED_ID,
+                isUnread = false,
+                updatedAt = Date(0L),
+            )
+        )
+        val rssRepository = mock<AbstractRssRepository>()
+
+        createHolder(
+            account = Account(
+                id = ACCOUNT_ID,
+                name = "FreshRSS",
+                type = AccountType(AccountType.FreshRSS.id),
+            ),
+            pendingReadStateOpDao = pendingReadStateOpDao,
+            rssRepository = rssRepository,
+        )
+
+        verify(rssRepository).batchMarkAsRead(setOf(ARTICLE_ID), markRead = true)
+        verify(pendingReadStateOpDao, never()).deleteByArticleIdsAndUnreadState(
+            articleIds = setOf(ARTICLE_ID),
+            isUnread = false,
+        )
+    }
+
+    private fun createHolder(
+        account: Account,
+        pendingReadStateOpDao: PendingReadStateOpDao,
+        rssRepository: AbstractRssRepository,
+    ): DiffMapHolder {
+        val context = mock<Context>()
+        whenever(context.cacheDir).thenReturn(
+            Files.createTempDirectory("diff-map-holder-pending-test").toFile()
+        )
+
+        val accountService = mock<AccountService>()
+        whenever(accountService.currentAccountFlow).thenReturn(MutableStateFlow(account))
+
+        val rssService = mock<RssService>()
+        whenever(rssService.get()).thenReturn(rssRepository)
+
+        return DiffMapHolder(
+            context = context,
+            applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined),
+            ioDispatcher = Dispatchers.Unconfined,
+            accountService = accountService,
+            rssService = rssService,
+            pendingReadStateOpDao = pendingReadStateOpDao,
+        )
+    }
+
+    private fun pendingReadStateOpDaoWith(
+        vararg ops: PendingReadStateOp
+    ): PendingReadStateOpDao {
+        val pendingReadStateOpDao = mock<PendingReadStateOpDao>()
+        runBlocking {
+            whenever(pendingReadStateOpDao.queryByAccountId(eq(ACCOUNT_ID))).thenReturn(ops.toList())
+        }
+        return pendingReadStateOpDao
+    }
+
+    private companion object {
+        const val ACCOUNT_ID = 1
+        const val ARTICLE_ID = "1\$article"
+        const val FEED_ID = "1\$feed"
+    }
+}


### PR DESCRIPTION
## Summary
- replay durable pending read-state ops into the local article table on account init
- keep remote pending ops queued until server sync succeeds, but delete local-account ops after local replay
- delete remote outbox rows by article id plus expected unread state to avoid dropping newer opposite-state ops
- add unit coverage for local and remote pending-op startup replay

## Root Cause
Unread-filter read changes can be deferred in memory so rows stay visible and grayed out. If the process dies before those deferred changes are committed to article.isUnread, only pending_read_state_op survives. Remote accounts did not replay that durable queue into the local DB on startup, so read articles could reappear as unread until a later successful sync.

Closes #67

## Validation
- ./gradlew :app:testGithubDebugUnitTest --tests me.ash.reader.domain.data.DiffMapHolderUpdateDiffTest --tests me.ash.reader.domain.data.DiffMapHolderPendingReadStateTest
- ./gradlew :app:connectedGithubDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=me.ash.reader.FreshRssSyncE2eTest#local_deferred_reads_commit_after_app_restart,me.ash.reader.FreshRssSyncE2eTest#remote_deferred_reads_commit_locally_after_app_restart_and_remain_pending_for_sync