### PR TITLE
[codex] Fix scrollable reader tables

### DIFF
--- a/app/src/androidTest/java/me/ash/reader/ui/component/webview/RYWebViewTableTest.kt
+++ b/app/src/androidTest/java/me/ash/reader/ui/component/webview/RYWebViewTableTest.kt
@@ -148,7 +148,9 @@ class RYWebViewTableTest {
             }
         }
         assertTrue(latch.await(5, TimeUnit.SECONDS))
-        val json = JSONTokener(encodedResult).nextValue() as String
+        val json =
+            JSONTokener(encodedResult ?: "null").nextValue() as? String
+                ?: throw AssertionError("Expected JavaScript to return encoded JSON, got: $encodedResult")
         return org.json.JSONObject(json)
     }
 

--- a/app/src/androidTest/java/me/ash/reader/ui/component/webview/RYWebViewTableTest.kt
+++ b/app/src/androidTest/java/me/ash/reader/ui/component/webview/RYWebViewTableTest.kt
@@ -32,6 +32,62 @@ class RYWebViewTableTest {
 
     @Test
     fun wideTableScrollsInsideWrapperWithoutWideningPage() {
+        loadArticle(WIDE_TABLE_HTML)
+
+        val metrics = evaluateJavascript(
+            """
+            (function() {
+                const wrapper = document.querySelector('.table-scroll');
+                const firstHeader = document.querySelector('th');
+                return JSON.stringify({
+                    wrapperClass: wrapper.className,
+                    wrapperCount: document.querySelectorAll('.table-scroll').length,
+                    pageClientWidth: document.documentElement.clientWidth,
+                    pageScrollWidth: document.documentElement.scrollWidth,
+                    wrapperClientWidth: wrapper.clientWidth,
+                    wrapperScrollWidth: wrapper.scrollWidth,
+                    firstHeaderBackground: getComputedStyle(firstHeader).backgroundColor,
+                    firstHeaderColor: getComputedStyle(firstHeader).color
+                });
+            })()
+            """.trimIndent()
+        )
+
+        assertEquals(1, metrics.getInt("wrapperCount"))
+        assertTrue(metrics.getString("wrapperClass").contains("table-scroll--reader"))
+        assertEquals("rgba(0, 0, 0, 0)", metrics.getString("firstHeaderBackground"))
+        assertEquals("rgb(17, 17, 17)", metrics.getString("firstHeaderColor"))
+        assertTrue(
+            "Expected wrapper to be horizontally scrollable: $metrics",
+            metrics.getInt("wrapperScrollWidth") > metrics.getInt("wrapperClientWidth"),
+        )
+        assertTrue(
+            "Expected page not to be horizontally scrollable: $metrics",
+            metrics.getInt("pageScrollWidth") <= metrics.getInt("pageClientWidth") + 1,
+        )
+    }
+
+    @Test
+    fun lightDarkTableStyleIsPreserved() {
+        loadArticle(DYNAMIC_TABLE_HTML)
+
+        val metrics = evaluateJavascript(
+            """
+            (function() {
+                const wrapper = document.querySelector('.table-scroll');
+                return JSON.stringify({
+                    wrapperClass: wrapper.className,
+                    wrapperCount: document.querySelectorAll('.table-scroll').length
+                });
+            })()
+            """.trimIndent()
+        )
+
+        assertEquals(1, metrics.getInt("wrapperCount"))
+        assertTrue(metrics.getString("wrapperClass").contains("table-scroll--dynamic"))
+    }
+
+    private fun loadArticle(content: String) {
         val pageLoaded = CountDownLatch(1)
         val html = WebViewHtml.HTML.format(
             WebViewStyle.get(
@@ -55,7 +111,7 @@ class RYWebViewTableTest {
                 selectionBgColor = 0xFF000000.toInt(),
             ),
             "https://example.com/",
-            WIDE_TABLE_HTML,
+            content,
             WebViewScript.get(boldCharacters = false),
         )
 
@@ -80,31 +136,6 @@ class RYWebViewTableTest {
         }
 
         assertTrue(pageLoaded.await(5, TimeUnit.SECONDS))
-
-        val metrics = evaluateJavascript(
-            """
-            (function() {
-                const wrapper = document.querySelector('.table-scroll');
-                return JSON.stringify({
-                    wrapperCount: document.querySelectorAll('.table-scroll').length,
-                    pageClientWidth: document.documentElement.clientWidth,
-                    pageScrollWidth: document.documentElement.scrollWidth,
-                    wrapperClientWidth: wrapper.clientWidth,
-                    wrapperScrollWidth: wrapper.scrollWidth
-                });
-            })()
-            """.trimIndent()
-        )
-
-        assertEquals(1, metrics.getInt("wrapperCount"))
-        assertTrue(
-            "Expected wrapper to be horizontally scrollable: $metrics",
-            metrics.getInt("wrapperScrollWidth") > metrics.getInt("wrapperClientWidth"),
-        )
-        assertTrue(
-            "Expected page not to be horizontally scrollable: $metrics",
-            metrics.getInt("pageScrollWidth") <= metrics.getInt("pageClientWidth") + 1,
-        )
     }
 
     private fun evaluateJavascript(script: String): org.json.JSONObject {
@@ -127,10 +158,10 @@ class RYWebViewTableTest {
             <table>
                 <thead>
                     <tr>
-                        <th style="white-space: nowrap">If you are using a public Wi-Fi network</th>
-                        <th style="white-space: nowrap">Always keep the VPN connected</th>
-                        <th style="white-space: nowrap">Non-negotiable protection against attacks on shared networks.</th>
-                        <th style="white-space: nowrap">WireGuard split tunneling recommendation</th>
+                        <th style="white-space: nowrap; background-color: rgb(0, 64, 96); color: white">If you are using a public Wi-Fi network</th>
+                        <th style="white-space: nowrap; background-color: rgb(0, 128, 64); color: white">Always keep the VPN connected</th>
+                        <th style="white-space: nowrap; background-color: rgb(220, 112, 0); color: white">Non-negotiable protection against attacks on shared networks.</th>
+                        <th style="white-space: nowrap; background-color: rgb(128, 144, 152); color: white">WireGuard split tunneling recommendation</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -143,6 +174,25 @@ class RYWebViewTableTest {
                 </tbody>
             </table>
             <p>After the table.</p>
+        """
+
+        const val DYNAMIC_TABLE_HTML = """
+            <style>
+                table.dynamic-theme th {
+                    background-color: light-dark(rgb(240, 240, 240), rgb(24, 24, 24));
+                    color: light-dark(rgb(0, 0, 0), rgb(255, 255, 255));
+                }
+            </style>
+            <table class="dynamic-theme">
+                <tr>
+                    <th style="white-space: nowrap">If you are...</th>
+                    <th style="white-space: nowrap">Then do this...</th>
+                </tr>
+                <tr>
+                    <td style="white-space: nowrap">On public Wi-Fi</td>
+                    <td style="white-space: nowrap">Always on</td>
+                </tr>
+            </table>
         """
     }
 }

--- a/app/src/androidTest/java/me/ash/reader/ui/component/webview/RYWebViewTableTest.kt
+++ b/app/src/androidTest/java/me/ash/reader/ui/component/webview/RYWebViewTableTest.kt
@@ -1,0 +1,148 @@
+package me.ash.reader.ui.component.webview
+
+import android.os.Handler
+import android.os.Looper
+import android.webkit.WebView
+import androidx.test.core.app.ActivityScenario
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import org.json.JSONTokener
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class RYWebViewTableTest {
+
+    private var webView: WebView? = null
+    private var scenario: ActivityScenario<WebViewTestActivity>? = null
+
+    @After
+    fun tearDown() {
+        scenario?.onActivity {
+            webView?.destroy()
+        }
+        scenario?.close()
+        webView = null
+        scenario = null
+    }
+
+    @Test
+    fun wideTableScrollsInsideWrapperWithoutWideningPage() {
+        val pageLoaded = CountDownLatch(1)
+        val html = WebViewHtml.HTML.format(
+            WebViewStyle.get(
+                fontSize = 24,
+                lineHeight = 1.3f,
+                letterSpacing = 0f,
+                textMargin = 24,
+                textColor = 0xFF222222.toInt(),
+                textBold = false,
+                textAlign = "start",
+                boldTextColor = 0xFF111111.toInt(),
+                subheadBold = true,
+                subheadUpperCase = false,
+                imgMargin = 0,
+                imgBorderRadius = 0,
+                linkTextColor = 0xFF0066CC.toInt(),
+                codeTextColor = 0xFF333333.toInt(),
+                codeBgColor = 0xFFEFEFEF.toInt(),
+                tableMargin = 24,
+                selectionTextColor = 0xFFFFFFFF.toInt(),
+                selectionBgColor = 0xFF000000.toInt(),
+            ),
+            "https://example.com/",
+            WIDE_TABLE_HTML,
+            WebViewScript.get(boldCharacters = false),
+        )
+
+        scenario = ActivityScenario.launch(WebViewTestActivity::class.java)
+        scenario!!.onActivity { activity ->
+            webView = WebView(activity).apply {
+                settings.javaScriptEnabled = true
+                webViewClient = object : android.webkit.WebViewClient() {
+                    override fun onPageFinished(view: WebView?, url: String?) {
+                        pageLoaded.countDown()
+                    }
+                }
+            }
+            activity.setContentView(webView)
+            webView!!.loadDataWithBaseURL(
+                "https://example.com/",
+                html,
+                "text/html",
+                "UTF-8",
+                null,
+            )
+        }
+
+        assertTrue(pageLoaded.await(5, TimeUnit.SECONDS))
+
+        val metrics = evaluateJavascript(
+            """
+            (function() {
+                const wrapper = document.querySelector('.table-scroll');
+                return JSON.stringify({
+                    wrapperCount: document.querySelectorAll('.table-scroll').length,
+                    pageClientWidth: document.documentElement.clientWidth,
+                    pageScrollWidth: document.documentElement.scrollWidth,
+                    wrapperClientWidth: wrapper.clientWidth,
+                    wrapperScrollWidth: wrapper.scrollWidth
+                });
+            })()
+            """.trimIndent()
+        )
+
+        assertEquals(1, metrics.getInt("wrapperCount"))
+        assertTrue(
+            "Expected wrapper to be horizontally scrollable: $metrics",
+            metrics.getInt("wrapperScrollWidth") > metrics.getInt("wrapperClientWidth"),
+        )
+        assertTrue(
+            "Expected page not to be horizontally scrollable: $metrics",
+            metrics.getInt("pageScrollWidth") <= metrics.getInt("pageClientWidth") + 1,
+        )
+    }
+
+    private fun evaluateJavascript(script: String): org.json.JSONObject {
+        val latch = CountDownLatch(1)
+        var encodedResult: String? = null
+        Handler(Looper.getMainLooper()).post {
+            webView!!.evaluateJavascript(script) {
+                encodedResult = it
+                latch.countDown()
+            }
+        }
+        assertTrue(latch.await(5, TimeUnit.SECONDS))
+        val json = JSONTokener(encodedResult).nextValue() as String
+        return org.json.JSONObject(json)
+    }
+
+    private companion object {
+        const val WIDE_TABLE_HTML = """
+            <p>Before the table.</p>
+            <table>
+                <thead>
+                    <tr>
+                        <th style="white-space: nowrap">If you are using a public Wi-Fi network</th>
+                        <th style="white-space: nowrap">Always keep the VPN connected</th>
+                        <th style="white-space: nowrap">Non-negotiable protection against attacks on shared networks.</th>
+                        <th style="white-space: nowrap">WireGuard split tunneling recommendation</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td style="white-space: nowrap">At home with a privacy focus</td>
+                        <td style="white-space: nowrap">Keep the VPN on</td>
+                        <td style="white-space: nowrap">Prevents your ISP from selling browsing data.</td>
+                        <td style="white-space: nowrap">Use personal app exclusions only when needed.</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p>After the table.</p>
+        """
+    }
+}

--- a/app/src/androidTest/java/me/ash/reader/ui/component/webview/RYWebViewTableTest.kt
+++ b/app/src/androidTest/java/me/ash/reader/ui/component/webview/RYWebViewTableTest.kt
@@ -87,6 +87,42 @@ class RYWebViewTableTest {
         assertTrue(metrics.getString("wrapperClass").contains("table-scroll--dynamic"))
     }
 
+    @Test
+    fun nestedTablesAreNormalizedWithoutScrollSizing() {
+        loadArticle(NESTED_TABLE_HTML)
+
+        val metrics = evaluateJavascript(
+            """
+            (function() {
+                const wrapper = document.querySelector('.table-scroll');
+                const outerTable = wrapper.children[0];
+                const nestedTable = wrapper.querySelector('td table');
+                const nestedHeader = nestedTable.querySelector('th');
+                const outerStyle = getComputedStyle(outerTable);
+                const nestedStyle = getComputedStyle(nestedTable);
+                return JSON.stringify({
+                    wrapperClass: wrapper.className,
+                    wrapperCount: document.querySelectorAll('.table-scroll').length,
+                    outerMinWidth: outerStyle.minWidth,
+                    nestedMinWidth: nestedStyle.minWidth,
+                    nestedHeaderBackground: getComputedStyle(nestedHeader).backgroundColor,
+                    nestedHeaderColor: getComputedStyle(nestedHeader).color
+                });
+            })()
+            """.trimIndent()
+        )
+
+        assertEquals(1, metrics.getInt("wrapperCount"))
+        assertTrue(metrics.getString("wrapperClass").contains("table-scroll--reader"))
+        assertEquals("100%", metrics.getString("outerMinWidth"))
+        assertTrue(
+            "Expected nested table not to receive root scroll sizing: $metrics",
+            metrics.getString("nestedMinWidth") != "100%",
+        )
+        assertEquals("rgba(0, 0, 0, 0)", metrics.getString("nestedHeaderBackground"))
+        assertEquals("rgb(17, 17, 17)", metrics.getString("nestedHeaderColor"))
+    }
+
     private fun loadArticle(content: String) {
         val pageLoaded = CountDownLatch(1)
         val html = WebViewHtml.HTML.format(
@@ -193,6 +229,30 @@ class RYWebViewTableTest {
                 <tr>
                     <td style="white-space: nowrap">On public Wi-Fi</td>
                     <td style="white-space: nowrap">Always on</td>
+                </tr>
+            </table>
+        """
+
+        const val NESTED_TABLE_HTML = """
+            <table>
+                <tr>
+                    <th style="white-space: nowrap">Outer header</th>
+                    <th style="white-space: nowrap">Outer detail</th>
+                </tr>
+                <tr>
+                    <td style="white-space: nowrap">Outer row</td>
+                    <td>
+                        <table>
+                            <tr>
+                                <th style="white-space: nowrap; background-color: rgb(0, 64, 96); color: white">Nested header</th>
+                                <th style="white-space: nowrap; background-color: rgb(0, 128, 64); color: white">Nested detail</th>
+                            </tr>
+                            <tr>
+                                <td style="white-space: nowrap">Nested row</td>
+                                <td style="white-space: nowrap">Nested value</td>
+                            </tr>
+                        </table>
+                    </td>
                 </tr>
             </table>
         """

--- a/app/src/debug/AndroidManifest.xml
+++ b/app/src/debug/AndroidManifest.xml
@@ -1,0 +1,7 @@
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+    <application>
+        <activity
+            android:name="me.ash.reader.ui.component.webview.WebViewTestActivity"
+            android:exported="false" />
+    </application>
+</manifest>

--- a/app/src/debug/java/me/ash/reader/ui/component/webview/WebViewTestActivity.kt
+++ b/app/src/debug/java/me/ash/reader/ui/component/webview/WebViewTestActivity.kt
@@ -1,0 +1,5 @@
+package me.ash.reader.ui.component.webview
+
+import android.app.Activity
+
+class WebViewTestActivity : Activity()

--- a/app/src/main/java/me/ash/reader/ui/component/webview/WebViewScript.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/WebViewScript.kt
@@ -93,7 +93,7 @@ function tableUsesDynamicTheme(table) {
 }
 
 document.querySelectorAll("table").forEach(function(table) {
-    if (table.closest(".table-scroll") || table.parentElement.closest("table")) {
+    if (table.closest(".table-scroll") || (table.parentElement && table.parentElement.closest("table"))) {
         return;
     }
 

--- a/app/src/main/java/me/ash/reader/ui/component/webview/WebViewScript.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/WebViewScript.kt
@@ -77,13 +77,30 @@ function setBold(enabled) {
 
 ${if (boldCharacters) "setBold(true);" else ""}
 
+const LIGHT_DARK_FUNCTION = /light-dark\s*\(/i;
+const TABLE_SELECTOR_PATTERN = /\b(table|thead|tbody|tfoot|tr|th|td)\b/i;
+
+function tableUsesDynamicTheme(table) {
+    const styledElements = [table, ...table.querySelectorAll("[style]")];
+    if (styledElements.some((element) => LIGHT_DARK_FUNCTION.test(element.getAttribute("style") || ""))) {
+        return true;
+    }
+
+    return [...document.querySelectorAll("style")].some((styleElement) => {
+        const css = styleElement.textContent || "";
+        return LIGHT_DARK_FUNCTION.test(css) && TABLE_SELECTOR_PATTERN.test(css);
+    });
+}
+
 document.querySelectorAll("table").forEach(function(table) {
     if (table.closest(".table-scroll") || table.parentElement.closest("table")) {
         return;
     }
 
     var wrapper = document.createElement("div");
-    wrapper.className = "table-scroll";
+    wrapper.className = tableUsesDynamicTheme(table)
+        ? "table-scroll table-scroll--dynamic"
+        : "table-scroll table-scroll--reader";
     table.parentNode.insertBefore(wrapper, table);
     wrapper.appendChild(table);
 });

--- a/app/src/main/java/me/ash/reader/ui/component/webview/WebViewScript.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/WebViewScript.kt
@@ -77,6 +77,17 @@ function setBold(enabled) {
 
 ${if (boldCharacters) "setBold(true);" else ""}
 
+document.querySelectorAll("table").forEach(function(table) {
+    if (table.closest(".table-scroll") || table.parentElement.closest("table")) {
+        return;
+    }
+
+    var wrapper = document.createElement("div");
+    wrapper.className = "table-scroll";
+    table.parentNode.insertBefore(wrapper, table);
+    wrapper.appendChild(table);
+});
+
 var images = document.querySelectorAll("img");
 
 images.forEach(function(img) {

--- a/app/src/main/java/me/ash/reader/ui/component/webview/WebViewStyle.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/WebViewStyle.kt
@@ -248,13 +248,22 @@ blockquote img {
 }
 
 /* Table  */
-table {
-    display: block;
-    max-width: var(--content-width) !important;
-    width: 100% !important;
+.table-scroll {
+    display: block !important;
+    max-width: 100% !important;
+    overflow-x: auto !important;
+    overflow-y: hidden !important;
+    margin-top: 1em !important;
+    margin-bottom: 1em !important;
+    -webkit-overflow-scrolling: touch;
+}
+
+.table-scroll table {
+    width: max-content !important;
+    min-width: 100% !important;
+    max-width: none !important;
     border-collapse: collapse !important;
-    margin-left: var(--table-margin) !important;
-    margin-right: var(--table-margin) !important;
+    margin: 0 !important;
 }
 
 table th,
@@ -264,14 +273,6 @@ table td {
     line-height: var(--line-height) !important;
     letter-spacing: var(--letter-spacing) !important;
     text-align: var(--text-align) !important;
-}
-
-table tr {
-    display: block;
-}
-
-table tr table tr td {
-    display: inline-block;
 }
 
 table tr:nth-child(even) {

--- a/app/src/main/java/me/ash/reader/ui/component/webview/WebViewStyle.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/WebViewStyle.kt
@@ -257,7 +257,7 @@ blockquote img {
     -webkit-overflow-scrolling: touch;
 }
 
-.table-scroll table {
+.table-scroll > table {
     width: max-content !important;
     min-width: 100% !important;
     max-width: none !important;

--- a/app/src/main/java/me/ash/reader/ui/component/webview/WebViewStyle.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/WebViewStyle.kt
@@ -67,10 +67,9 @@ ${applyFontFace(fontPath)}
     --blockquote-border-width: 3px;
     --blockquote-border-color: ${argbToCssColor(textColor)}33;
     --table-margin: ${tableMargin}px;
-    --table-border-width;
-    --table-border-color;
+    --table-border-width: 1px;
+    --table-border-color: ${argbToCssColor(textColor)}22;
     --table-cell-padding: 0.2em;
-    --table-alt-row-bg-color;
     --code-text-color: ${argbToCssColor(codeTextColor)};
     --code-bg-color: ${argbToCssColor(codeBgColor)};
     --code-scrollbar-color: ${argbToCssColor(codeTextColor)}22;
@@ -266,17 +265,35 @@ blockquote img {
     margin: 0 !important;
 }
 
-table th,
-table td {
+.table-scroll--reader table,
+.table-scroll--reader thead,
+.table-scroll--reader tbody,
+.table-scroll--reader tr,
+.table-scroll--reader th,
+.table-scroll--reader td {
+    color: var(--text-color) !important;
+    background: transparent !important;
+    background-color: transparent !important;
+    background-image: none !important;
+}
+
+.table-scroll--reader table {
     border: var(--table-border-width) solid var(--table-border-color) !important;
-    padding: var(--table-cell-padding) !important;
+}
+
+.table-scroll--reader th,
+.table-scroll--reader td {
+    border: var(--table-border-width) solid var(--table-border-color) !important;
+    padding: 0.6em 0.8em !important;
     line-height: var(--line-height) !important;
     letter-spacing: var(--letter-spacing) !important;
     text-align: var(--text-align) !important;
+    vertical-align: top !important;
 }
 
-table tr:nth-child(even) {
-    background-color: var(--table-alt-row-bg-color) !important;
+.table-scroll--reader th {
+    color: var(--bold-text-color) !important;
+    font-weight: 600 !important;
 }
 
 /* Code */


### PR DESCRIPTION
Closes #72

## Summary
- wrap article tables in a WebView scroll container so wide tables scroll horizontally on their own
- preserve normal table layout instead of forcing rows into block layout
- add an emulator-backed WebView regression test for wide table overflow

## video


https://github.com/user-attachments/assets/f36b5178-3d4c-40a5-95ee-8ec5c1b56558



## Validation
- ./gradlew :app:compileGithubDebugKotlin :app:compileGithubDebugAndroidTestKotlin
- ./gradlew :app:connectedGithubDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=me.ash.reader.ui.component.webview.RYWebViewTableTest
- Manual emulator smoke test: installed and launched githubDebug for visual testing