### PR TITLE
fix(freshrss): normalize greader server url without trailing slash

### DIFF
--- a/app/src/main/java/me/ash/reader/infrastructure/rss/provider/greader/GoogleReaderAPI.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/rss/provider/greader/GoogleReaderAPI.kt
@@ -539,6 +539,7 @@ private constructor(
 
         fun normalizeServerUrl(serverUrl: String): String {
             val trimmedUrl = serverUrl.trim()
+            if (trimmedUrl.isEmpty()) return trimmedUrl
             return if (trimmedUrl.endsWith("/")) trimmedUrl else "$trimmedUrl/"
         }
 

--- a/app/src/main/java/me/ash/reader/infrastructure/rss/provider/greader/GoogleReaderAPI.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/rss/provider/greader/GoogleReaderAPI.kt
@@ -537,6 +537,11 @@ private constructor(
 
         private val instances: ConcurrentHashMap<String, GoogleReaderAPI> = ConcurrentHashMap()
 
+        fun normalizeServerUrl(serverUrl: String): String {
+            val trimmedUrl = serverUrl.trim()
+            return if (trimmedUrl.endsWith("/")) trimmedUrl else "$trimmedUrl/"
+        }
+
         fun getInstance(
             context: Context,
             serverUrl: String,
@@ -547,19 +552,21 @@ private constructor(
             clientCertificateAlias: String? = null,
             syncLogger: SyncLogger,
         ): GoogleReaderAPI =
-            instances.getOrPut(
-                "$serverUrl$username$password$httpUsername$httpPassword$clientCertificateAlias"
-            ) {
-                GoogleReaderAPI(
-                    context,
-                    serverUrl,
-                    username,
-                    password,
-                    httpUsername,
-                    httpPassword,
-                    syncLogger,
-                    clientCertificateAlias,
-                )
+            normalizeServerUrl(serverUrl).let { normalizedServerUrl ->
+                instances.getOrPut(
+                    "$normalizedServerUrl$username$password$httpUsername$httpPassword$clientCertificateAlias"
+                ) {
+                    GoogleReaderAPI(
+                        context,
+                        normalizedServerUrl,
+                        username,
+                        password,
+                        httpUsername,
+                        httpPassword,
+                        syncLogger,
+                        clientCertificateAlias,
+                    )
+                }
             }
 
         fun clearInstance() {

--- a/app/src/main/java/me/ash/reader/ui/page/settings/accounts/connection/FreshRSSConnection.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/accounts/connection/FreshRSSConnection.kt
@@ -33,7 +33,7 @@ fun LazyItemScope.FreshRSSConnection(
 
     var passwordMask by remember { mutableStateOf(securityKey.password?.mask()) }
 
-    var serverUrlValue by remember { mutableStateOf(securityKey.serverUrl) }
+    var serverUrlValue by remember { mutableStateOf(securityKey.serverUrl.orEmpty()) }
     var usernameValue by remember { mutableStateOf(securityKey.username) }
     var passwordValue by remember { mutableStateOf(securityKey.password) }
 
@@ -79,13 +79,13 @@ fun LazyItemScope.FreshRSSConnection(
     TextFieldDialog(
         visible = serverUrlDialogVisible,
         title = stringResource(R.string.server_url),
-        value = serverUrlValue ?: "",
+        value = serverUrlValue,
         placeholder = "https://demo.freshrss.org/api/greader.php",
         onValueChange = { serverUrlValue = it },
         onDismissRequest = { serverUrlDialogVisible = false },
         onConfirm = {
-            if (serverUrlValue?.isNotBlank() == true) {
-                securityKey.serverUrl = GoogleReaderAPI.normalizeServerUrl(serverUrlValue!!)
+            if (serverUrlValue.isNotBlank()) {
+                securityKey.serverUrl = GoogleReaderAPI.normalizeServerUrl(serverUrlValue)
                 save(account, viewModel, securityKey)
                 serverUrlDialogVisible = false
             }

--- a/app/src/main/java/me/ash/reader/ui/page/settings/accounts/connection/FreshRSSConnection.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/accounts/connection/FreshRSSConnection.kt
@@ -16,6 +16,7 @@ import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
 import me.ash.reader.R
 import me.ash.reader.domain.model.account.Account
 import me.ash.reader.domain.model.account.security.FreshRSSSecurityKey
+import me.ash.reader.infrastructure.rss.provider.greader.GoogleReaderAPI
 import me.ash.reader.ui.component.base.TextFieldDialog
 import me.ash.reader.ui.ext.mask
 import me.ash.reader.ui.page.settings.SettingItem
@@ -83,8 +84,8 @@ fun LazyItemScope.FreshRSSConnection(
         onValueChange = { serverUrlValue = it },
         onDismissRequest = { serverUrlDialogVisible = false },
         onConfirm = {
-            if (securityKey.serverUrl?.isNotBlank() == true) {
-                securityKey.serverUrl = serverUrlValue
+            if (serverUrlValue?.isNotBlank() == true) {
+                securityKey.serverUrl = GoogleReaderAPI.normalizeServerUrl(serverUrlValue!!)
                 save(account, viewModel, securityKey)
                 serverUrlDialogVisible = false
             }

--- a/app/src/test/java/me/ash/reader/infrastructure/rss/GoogleReaderServerUrlNormalizationTest.kt
+++ b/app/src/test/java/me/ash/reader/infrastructure/rss/GoogleReaderServerUrlNormalizationTest.kt
@@ -26,4 +26,11 @@ class GoogleReaderServerUrlNormalizationTest {
 
         assertEquals("https://demo.freshrss.org/api/greader.php/", normalized)
     }
+
+    @Test
+    fun normalizeServerUrl_returnsEmptyStringForBlankInput() {
+        val normalized = GoogleReaderAPI.normalizeServerUrl("   ")
+
+        assertEquals("", normalized)
+    }
 }

--- a/app/src/test/java/me/ash/reader/infrastructure/rss/GoogleReaderServerUrlNormalizationTest.kt
+++ b/app/src/test/java/me/ash/reader/infrastructure/rss/GoogleReaderServerUrlNormalizationTest.kt
@@ -1,0 +1,29 @@
+package me.ash.reader.infrastructure.rss
+
+import me.ash.reader.infrastructure.rss.provider.greader.GoogleReaderAPI
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class GoogleReaderServerUrlNormalizationTest {
+
+    @Test
+    fun normalizeServerUrl_appendsTrailingSlashWhenMissing() {
+        val normalized = GoogleReaderAPI.normalizeServerUrl("https://demo.freshrss.org/api/greader.php")
+
+        assertEquals("https://demo.freshrss.org/api/greader.php/", normalized)
+    }
+
+    @Test
+    fun normalizeServerUrl_keepsExistingTrailingSlash() {
+        val normalized = GoogleReaderAPI.normalizeServerUrl("https://demo.freshrss.org/api/greader.php/")
+
+        assertEquals("https://demo.freshrss.org/api/greader.php/", normalized)
+    }
+
+    @Test
+    fun normalizeServerUrl_trimsWhitespaceBeforeNormalizing() {
+        val normalized = GoogleReaderAPI.normalizeServerUrl("  https://demo.freshrss.org/api/greader.php  ")
+
+        assertEquals("https://demo.freshrss.org/api/greader.php/", normalized)
+    }
+}


### PR DESCRIPTION
## Summary
- normalize Google Reader/FreshRSS server URLs in API instance creation so missing trailing slash is handled automatically
- normalize FreshRSS connection URL when saved from account settings
- add regression tests for URL normalization behavior

Closes #71