### PR TITLE
fix: stop article media playback after leaving reader

### DIFF
--- a/app/src/androidTest/java/me/ash/reader/ui/component/webview/RYWebViewMediaLifecycleTest.kt
+++ b/app/src/androidTest/java/me/ash/reader/ui/component/webview/RYWebViewMediaLifecycleTest.kt
@@ -1,0 +1,66 @@
+package me.ash.reader.ui.component.webview
+
+import android.webkit.WebView
+import androidx.activity.ComponentActivity
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.CompositionLocalProvider
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.test.junit4.createAndroidComposeRule
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertThrows
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(AndroidJUnit4::class)
+class RYWebViewMediaLifecycleTest {
+
+    @get:Rule
+    val composeRule = createAndroidComposeRule<ComponentActivity>()
+
+    @Test
+    fun articleWebViewIsDestroyedWhenRemovedFromComposition() {
+        var showArticle by mutableStateOf(true)
+        var articleWebView: WebView? = null
+
+        composeRule.setContent {
+            MaterialTheme {
+                CompositionLocalProvider(
+                    LocalWebViewCreatedForTest provides { articleWebView = it },
+                ) {
+                    if (showArticle) {
+                        RYWebView(content = MEDIA_ARTICLE_HTML)
+                    }
+                }
+            }
+        }
+
+        composeRule.waitUntil {
+            articleWebView != null
+        }
+
+        composeRule.runOnIdle {
+            showArticle = false
+        }
+        composeRule.waitForIdle()
+
+        assertNotNull(articleWebView)
+        assertThrows(
+            "Expected a removed article WebView to be destroyed so in-page audio/video cannot keep running.",
+            Throwable::class.java,
+        ) {
+            articleWebView!!.evaluateJavascript("document.querySelector('audio').paused", null)
+        }
+    }
+
+    private companion object {
+        const val MEDIA_ARTICLE_HTML = """
+            <p>Article with embedded audio.</p>
+            <audio src="data:audio/wav;base64,UklGRiQAAABXQVZFZm10IBAAAAABAAEAESsAACJWAAACABAAZGF0YQAAAAA=" controls></audio>
+            <video src="data:video/mp4;base64," controls></video>
+        """
+    }
+}

--- a/app/src/androidTest/java/me/ash/reader/ui/component/webview/RYWebViewMediaLifecycleTest.kt
+++ b/app/src/androidTest/java/me/ash/reader/ui/component/webview/RYWebViewMediaLifecycleTest.kt
@@ -48,11 +48,13 @@ class RYWebViewMediaLifecycleTest {
         composeRule.waitForIdle()
 
         assertNotNull(articleWebView)
-        assertThrows(
-            "Expected a removed article WebView to be destroyed so in-page audio/video cannot keep running.",
-            Throwable::class.java,
-        ) {
-            articleWebView!!.evaluateJavascript("document.querySelector('audio').paused", null)
+        composeRule.runOnUiThread {
+            assertThrows(
+                "Expected a removed article WebView to be destroyed so in-page audio/video cannot keep running.",
+                IllegalStateException::class.java,
+            ) {
+                articleWebView!!.evaluateJavascript("document.querySelector('audio').paused", null)
+            }
         }
     }
 

--- a/app/src/main/java/me/ash/reader/ui/component/webview/RYWebView.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/RYWebView.kt
@@ -10,6 +10,8 @@ import android.webkit.WebChromeClient
 import android.webkit.WebView
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -41,6 +43,8 @@ import me.ash.reader.ui.ext.ExternalFonts
 import me.ash.reader.ui.ext.openURL
 import me.ash.reader.ui.ext.surfaceColorAtElevation
 import me.ash.reader.ui.theme.palette.alwaysLight
+
+internal val LocalWebViewCreatedForTest = compositionLocalOf<((WebView) -> Unit)?> { null }
 
 /**
  * Custom WebView that detects horizontal gestures and tells parent views not to intercept.
@@ -120,6 +124,7 @@ fun RYWebView(
     val codeBgColor: Int =
         MaterialTheme.colorScheme.surfaceColorAtElevation((tonalElevation.value + 6).dp).toArgb()
     val boldCharacters = LocalReadingBoldCharacters.current
+    val onWebViewCreatedForTest = LocalWebViewCreatedForTest.current
 
     val webChromeClient = remember(onShowCustomView, onHideCustomView) {
         if (onShowCustomView != null && onHideCustomView != null) {
@@ -147,7 +152,7 @@ fun RYWebView(
                     webChromeClient = webChromeClient,
                     onImageClick = onImageClick,
                     onLinkLongPress = onLinkLongPress,
-                )
+                ).also { onWebViewCreatedForTest?.invoke(it) }
             )
         }
 
@@ -158,6 +163,12 @@ fun RYWebView(
             "/android_res/font/google_sans_flex.ttf"
         } else null
     val htmlBaseUrl = baseUrl ?: "about:blank"
+
+    DisposableEffect(webView) {
+        onDispose {
+            webView.releaseArticleMedia(webChromeClient)
+        }
+    }
 
     AndroidView(
         modifier = modifier,
@@ -201,4 +212,30 @@ fun RYWebView(
             )
         },
     )
+}
+
+private fun WebView.releaseArticleMedia(webChromeClient: RYWebChromeClient?) {
+    webChromeClient?.releaseCustomView()
+
+    runCatching {
+        evaluateJavascript(
+            """
+            (function() {
+                document.querySelectorAll('audio, video').forEach(function(media) {
+                    media.pause();
+                    media.removeAttribute('src');
+                    media.load();
+                });
+            })();
+            """.trimIndent(),
+            null,
+        )
+    }
+    runCatching { stopLoading() }
+    runCatching { loadUrl("about:blank") }
+    runCatching { onPause() }
+    runCatching { removeAllViews() }
+    runCatching { this.webChromeClient = null }
+    runCatching { this.webViewClient = android.webkit.WebViewClient() }
+    runCatching { destroy() }
 }

--- a/app/src/main/java/me/ash/reader/ui/component/webview/RYWebView.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/RYWebView.kt
@@ -15,6 +15,7 @@ import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
@@ -134,9 +135,10 @@ fun RYWebView(
             )
         } else null
     }
+    val latestWebChromeClient by rememberUpdatedState(webChromeClient)
 
     val webView by
-        remember(backgroundColor, webChromeClient) {
+        remember {
             mutableStateOf(
                 WebViewLayout.get(
                     context = context,
@@ -149,7 +151,7 @@ fun RYWebView(
                                 context.openURL(url, openLink, openLinkSpecificBrowser)
                             },
                         ),
-                    webChromeClient = webChromeClient,
+                    webChromeClient = null,
                     onImageClick = onImageClick,
                     onLinkLongPress = onLinkLongPress,
                 ).also { onWebViewCreatedForTest?.invoke(it) }
@@ -164,9 +166,9 @@ fun RYWebView(
         } else null
     val htmlBaseUrl = baseUrl ?: "about:blank"
 
-    DisposableEffect(webView) {
+    DisposableEffect(Unit) {
         onDispose {
-            webView.releaseArticleMedia(webChromeClient)
+            webView.releaseArticleMedia(latestWebChromeClient)
         }
     }
 
@@ -174,6 +176,7 @@ fun RYWebView(
         modifier = modifier,
         factory = { webView },
         update = { wv ->
+            wv.webChromeClient = webChromeClient
                 Timber.tag("RLog").i("maxWidth: ${maxWidth}")
                 Timber.tag("RLog").i("readingFont: ${context.filesDir.absolutePath}")
                 Timber.tag("RLog").i("CustomWebView: ${content}")
@@ -216,21 +219,7 @@ fun RYWebView(
 
 private fun WebView.releaseArticleMedia(webChromeClient: RYWebChromeClient?) {
     webChromeClient?.releaseCustomView()
-
-    runCatching {
-        evaluateJavascript(
-            """
-            (function() {
-                document.querySelectorAll('audio, video').forEach(function(media) {
-                    media.pause();
-                    media.removeAttribute('src');
-                    media.load();
-                });
-            })();
-            """.trimIndent(),
-            null,
-        )
-    }
+    (parent as? android.view.ViewGroup)?.removeView(this)
     runCatching { stopLoading() }
     runCatching { loadUrl("about:blank") }
     runCatching { onPause() }

--- a/app/src/main/java/me/ash/reader/ui/component/webview/RYWebView.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/RYWebView.kt
@@ -127,15 +127,18 @@ fun RYWebView(
     val boldCharacters = LocalReadingBoldCharacters.current
     val onWebViewCreatedForTest = LocalWebViewCreatedForTest.current
 
-    val webChromeClient = remember(onShowCustomView, onHideCustomView) {
-        if (onShowCustomView != null && onHideCustomView != null) {
-            RYWebChromeClient(
-                onShowCustomViewCallback = onShowCustomView,
-                onHideCustomViewCallback = onHideCustomView,
-            )
-        } else null
+    val onShowCustomViewState by rememberUpdatedState(onShowCustomView)
+    val onHideCustomViewState by rememberUpdatedState(onHideCustomView)
+    val webChromeClient = remember {
+        RYWebChromeClient(
+            onShowCustomViewCallback = { view, callback ->
+                onShowCustomViewState?.invoke(view, callback)
+            },
+            onHideCustomViewCallback = {
+                onHideCustomViewState?.invoke()
+            },
+        )
     }
-    val latestWebChromeClient by rememberUpdatedState(webChromeClient)
 
     val webView by
         remember {
@@ -168,7 +171,7 @@ fun RYWebView(
 
     DisposableEffect(Unit) {
         onDispose {
-            webView.releaseArticleMedia(latestWebChromeClient)
+            webView.releaseArticleMedia(webChromeClient)
         }
     }
 
@@ -176,7 +179,8 @@ fun RYWebView(
         modifier = modifier,
         factory = { webView },
         update = { wv ->
-            wv.webChromeClient = webChromeClient
+            wv.webChromeClient =
+                if (onShowCustomView != null && onHideCustomView != null) webChromeClient else null
                 Timber.tag("RLog").i("maxWidth: ${maxWidth}")
                 Timber.tag("RLog").i("readingFont: ${context.filesDir.absolutePath}")
                 Timber.tag("RLog").i("CustomWebView: ${content}")


### PR DESCRIPTION
## Summary
- stop and tear down article WebView media when the reader content leaves composition
- release fullscreen custom view and destroy the WebView instance during disposal
- add an Android instrumentation regression test covering WebView teardown after article exit

## Verification
- ./gradlew :app:compileGithubDebugKotlin
- ./gradlew :app:compileGithubDebugAndroidTestKotlin

Closes #79