### PR TITLE
fix(flow): add reliable undo for batch mark-read actions

### DIFF
--- a/app/src/main/java/me/ash/reader/domain/data/DiffMapHolder.kt
+++ b/app/src/main/java/me/ash/reader/domain/data/DiffMapHolder.kt
@@ -283,6 +283,45 @@ class DiffMapHolder @Inject constructor(
         }
     }
 
+    fun applyReadStateWithSync(
+        articleWithFeed: List<ArticleWithFeed>,
+        markRead: Boolean,
+    ) {
+        if (articleWithFeed.isEmpty()) return
+
+        val appliedDiffs =
+            articleWithFeed
+                .distinctBy { it.article.id }
+                .map { Diff(isRead = markRead, articleWithFeed = it) }
+
+        if (shouldSyncWithRemote) {
+            appliedDiffs.forEach(::appendDiffToSync)
+        }
+
+        enqueuePendingReadStateWork {
+            persistPendingReadStateOps(appliedDiffs)
+            commitAppliedDiffsToDb(appliedDiffs.associateBy { it.articleId })
+        }
+    }
+
+    fun applyReadStateWithSync(
+        articleIds: Set<String>,
+        markRead: Boolean,
+    ) {
+        if (articleIds.isEmpty()) return
+
+        val appliedDiffs = articleIds.map { Diff(isRead = markRead, articleId = it, feedId = "") }
+
+        if (shouldSyncWithRemote) {
+            appliedDiffs.forEach(::appendDiffToSync)
+        }
+
+        enqueuePendingReadStateWork {
+            persistPendingReadStateOps(appliedDiffs)
+            commitAppliedDiffsToDb(appliedDiffs.associateBy { it.articleId })
+        }
+    }
+
     /**
      * Flushes any deferred DB commits. Call this when exiting the Unread filter view,
      * starting a sync, or when the user navigates away from the flow page.

--- a/app/src/main/java/me/ash/reader/domain/service/AbstractRssRepository.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/AbstractRssRepository.kt
@@ -103,9 +103,45 @@ abstract class AbstractRssRepository(
         articleId: String?,
         before: Date?,
         markRead: Boolean,
-    ) {
+    ): Set<String> {
         val storedUnread = !markRead
         val accountId = accountService.getCurrentAccountId()
+        val affectedIds =
+            when {
+                groupId != null -> {
+                    articleDao
+                        .queryMetadataByGroupIdWhenIsUnread(
+                            accountId = accountId,
+                            groupId = groupId,
+                            isUnread = !storedUnread,
+                            before = before ?: Date(Long.MAX_VALUE),
+                        )
+                        .map { it.id }
+                }
+
+                feedId != null -> {
+                    articleDao
+                        .queryMetadataByFeedId(
+                            accountId = accountId,
+                            feedId = feedId,
+                            isUnread = !storedUnread,
+                            before = before ?: Date(Long.MAX_VALUE),
+                        )
+                        .map { it.id }
+                }
+
+                articleId != null -> listOf(articleId)
+
+                else -> {
+                    articleDao
+                        .queryMetadataAll(
+                            accountId = accountId,
+                            isUnread = !storedUnread,
+                            before = before ?: Date(Long.MAX_VALUE),
+                        )
+                        .map { it.id }
+                }
+            }.toSet()
         when {
             groupId != null -> {
                 articleDao.markAllAsReadByGroupId(
@@ -133,6 +169,7 @@ abstract class AbstractRssRepository(
                 articleDao.markAllAsRead(accountId, storedUnread, before ?: Date(Long.MAX_VALUE))
             }
         }
+        return affectedIds
     }
 
     open suspend fun batchMarkAsRead(articleIds: Set<String>, markRead: Boolean) {

--- a/app/src/main/java/me/ash/reader/domain/service/FeverRssService.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/FeverRssService.kt
@@ -337,8 +337,8 @@ constructor(
         articleId: String?,
         before: Date?,
         markRead: Boolean,
-    ) {
-        super.markAsRead(groupId, feedId, articleId, before, markRead)
+    ): Set<String> {
+        val affectedIds = super.markAsRead(groupId, feedId, articleId, before, markRead)
         val feverAPI = getFeverAPI()
         val targetStatus = if (markRead) FeverDTO.StatusEnum.Read else FeverDTO.StatusEnum.Unread
         val beforeUnixTimestamp = (before?.time ?: Date(Long.MAX_VALUE).time) / 1000
@@ -376,6 +376,7 @@ constructor(
                 }
             }
         }
+        return affectedIds
     }
 
     @CheckResult

--- a/app/src/main/java/me/ash/reader/domain/service/FeverRssService.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/FeverRssService.kt
@@ -342,39 +342,46 @@ constructor(
         val feverAPI = getFeverAPI()
         val targetStatus = if (markRead) FeverDTO.StatusEnum.Read else FeverDTO.StatusEnum.Unread
         val beforeUnixTimestamp = (before?.time ?: Date(Long.MAX_VALUE).time) / 1000
-        when {
-            groupId != null -> {
-                feverAPI.markGroup(
-                    status = targetStatus,
-                    id = groupId.dollarLast().toLong(),
-                    before = beforeUnixTimestamp,
-                )
-            }
-
-            feedId != null -> {
-                feverAPI.markFeed(
-                    status = targetStatus,
-                    id = feedId.dollarLast().toLong(),
-                    before = beforeUnixTimestamp,
-                )
-            }
-
-            articleId != null -> {
-                feverAPI.markItem(
-                    status = targetStatus,
-                    id = articleId.dollarLast(),
-                )
-            }
-
-            else -> {
-                feedDao.queryAll(accountService.getCurrentAccountId()).forEach {
-                    feverAPI.markFeed(
+        try {
+            when {
+                groupId != null -> {
+                    feverAPI.markGroup(
                         status = targetStatus,
-                        id = it.id.dollarLast().toLong(),
+                        id = groupId.dollarLast().toLong(),
                         before = beforeUnixTimestamp,
                     )
                 }
+
+                feedId != null -> {
+                    feverAPI.markFeed(
+                        status = targetStatus,
+                        id = feedId.dollarLast().toLong(),
+                        before = beforeUnixTimestamp,
+                    )
+                }
+
+                articleId != null -> {
+                    feverAPI.markItem(
+                        status = targetStatus,
+                        id = articleId.dollarLast(),
+                    )
+                }
+
+                else -> {
+                    feedDao.queryAll(accountService.getCurrentAccountId()).forEach {
+                        feverAPI.markFeed(
+                            status = targetStatus,
+                            id = it.id.dollarLast().toLong(),
+                            before = beforeUnixTimestamp,
+                        )
+                    }
+                }
             }
+        } catch (exception: Exception) {
+            throw MarkReadStatusPartiallyAppliedException(
+                affectedIds = affectedIds,
+                cause = exception,
+            )
         }
         return affectedIds
     }

--- a/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
@@ -866,17 +866,24 @@ constructor(
             }.toSet()
         super.markAsRead(groupId, feedId, articleId, before, markRead)
         val markList = affectedIds.map { it.dollarLast() }
-        markList
-            .takeIf { it.isNotEmpty() }
-            ?.chunked(500)
-            ?.forEachIndexed { index, it ->
-                        Timber.tag("RLog").d("sync markAsRead:  ${(index * 500) + it.size}/${markList.size} num")
-                googleReaderAPI.editTag(
-                    itemIds = it,
-                    mark = if (markRead) GoogleReaderAPI.Stream.Read.tag else null,
-                    unmark = if (!markRead) GoogleReaderAPI.Stream.Read.tag else null,
-                )
-            }
+        try {
+            markList
+                .takeIf { it.isNotEmpty() }
+                ?.chunked(500)
+                ?.forEachIndexed { index, it ->
+                            Timber.tag("RLog").d("sync markAsRead:  ${(index * 500) + it.size}/${markList.size} num")
+                    googleReaderAPI.editTag(
+                        itemIds = it,
+                        mark = if (markRead) GoogleReaderAPI.Stream.Read.tag else null,
+                        unmark = if (!markRead) GoogleReaderAPI.Stream.Read.tag else null,
+                    )
+                }
+        } catch (exception: Exception) {
+            throw MarkReadStatusPartiallyAppliedException(
+                affectedIds = affectedIds,
+                cause = exception,
+            )
+        }
         return affectedIds
     }
 

--- a/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/GoogleReaderRssService.kt
@@ -818,11 +818,11 @@ constructor(
         articleId: String?,
         before: Date?,
         markRead: Boolean,
-    ) {
+    ): Set<String> {
         val storedUnread = !markRead
         val accountId = accountService.getCurrentAccountId()
         val googleReaderAPI = getGoogleReaderAPI()
-        val markList: List<String> =
+        val affectedIds: Set<String> =
             when {
                 groupId != null -> {
                     if (before == null) {
@@ -839,7 +839,7 @@ constructor(
                                 before = before,
                             )
                         }
-                        .map { it.id.dollarLast() }
+                        .map { it.id }
                 }
 
                 feedId != null -> {
@@ -848,11 +848,11 @@ constructor(
                         } else {
                             articleDao.queryMetadataByFeedId(accountId, feedId, isUnread = !storedUnread, before = before)
                         }
-                        .map { it.id.dollarLast() }
+                        .map { it.id }
                 }
 
                 articleId != null -> {
-                    listOf(articleId.dollarLast())
+                    listOf(articleId)
                 }
 
                 else -> {
@@ -861,10 +861,11 @@ constructor(
                         } else {
                             articleDao.queryMetadataAll(accountId, isUnread = !storedUnread, before = before)
                         }
-                        .map { it.id.dollarLast() }
+                        .map { it.id }
                 }
-            }
+            }.toSet()
         super.markAsRead(groupId, feedId, articleId, before, markRead)
+        val markList = affectedIds.map { it.dollarLast() }
         markList
             .takeIf { it.isNotEmpty() }
             ?.chunked(500)
@@ -876,6 +877,7 @@ constructor(
                     unmark = if (!markRead) GoogleReaderAPI.Stream.Read.tag else null,
                 )
             }
+        return affectedIds
     }
 
     override suspend fun syncReadStatus(articleIds: Set<String>, markRead: Boolean): Set<String> {

--- a/app/src/main/java/me/ash/reader/domain/service/MarkReadStatusPartiallyAppliedException.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/MarkReadStatusPartiallyAppliedException.kt
@@ -1,0 +1,6 @@
+package me.ash.reader.domain.service
+
+class MarkReadStatusPartiallyAppliedException(
+    val affectedIds: Set<String>,
+    cause: Throwable,
+) : RuntimeException(cause)

--- a/app/src/main/java/me/ash/reader/ui/page/adaptive/ArticleListReaderViewModel.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/adaptive/ArticleListReaderViewModel.kt
@@ -147,9 +147,27 @@ constructor(
         conditions: MarkAsReadConditions,
         markRead: Boolean,
     ) {
-        applicationScope.launch(ioDispatcher) {
-            markReadStatus(groupId, feedId, articleId, conditions, markRead)
-        }
+        launchMarkReadStatus(
+            applicationScope = applicationScope,
+            ioDispatcher = ioDispatcher,
+            markReadStatus = { markReadStatus(groupId, feedId, articleId, conditions, markRead) },
+        )
+    }
+
+    fun markReadStatusInBackground(
+        groupId: String?,
+        feedId: String?,
+        articleId: String?,
+        conditions: MarkAsReadConditions,
+        markRead: Boolean,
+        onMarked: (Set<String>) -> Unit = {},
+    ) {
+        launchMarkReadStatus(
+            applicationScope = applicationScope,
+            ioDispatcher = ioDispatcher,
+            markReadStatus = { markReadStatus(groupId, feedId, articleId, conditions, markRead) },
+            onMarked = onMarked,
+        )
     }
 
     suspend fun markReadStatus(

--- a/app/src/main/java/me/ash/reader/ui/page/adaptive/ArticleListReaderViewModel.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/adaptive/ArticleListReaderViewModel.kt
@@ -148,6 +148,18 @@ constructor(
         markRead: Boolean,
     ) {
         applicationScope.launch(ioDispatcher) {
+            markReadStatus(groupId, feedId, articleId, conditions, markRead)
+        }
+    }
+
+    suspend fun markReadStatus(
+        groupId: String?,
+        feedId: String?,
+        articleId: String?,
+        conditions: MarkAsReadConditions,
+        markRead: Boolean,
+    ): Set<String> =
+        kotlinx.coroutines.withContext(ioDispatcher) {
             rssService
                 .get()
                 .markAsRead(
@@ -157,6 +169,12 @@ constructor(
                     before = conditions.toDate(),
                     markRead = markRead,
                 )
+        }
+
+    fun undoReadStatus(articleIds: Set<String>) {
+        if (articleIds.isEmpty()) return
+        applicationScope.launch(ioDispatcher) {
+            rssService.get().batchMarkAsRead(articleIds = articleIds, markRead = false)
         }
     }
 
@@ -168,23 +186,25 @@ constructor(
         }
     }
 
-    fun markAsReadFromListByDate(date: Date, isBefore: Boolean) {
-        viewModelScope.launch(ioDispatcher) {
-            val items =
-                articleListUseCase.itemSnapshotList
-                    .filterIsInstance<ArticleFlowItem.Article>()
-                    .map { it.articleWithFeed }
-                    .filter {
-                        if (isBefore) {
-                            date > it.article.date && !it.article.isRead
-                        } else {
-                            date < it.article.date && !it.article.isRead
-                        }
+    fun markAsReadFromListByDate(date: Date, isBefore: Boolean): List<ArticleWithFeed> {
+        val items =
+            articleListUseCase.itemSnapshotList
+                .filterIsInstance<ArticleFlowItem.Article>()
+                .map { it.articleWithFeed }
+                .filter {
+                    val isRead = diffMapHolder.checkIfRead(it)
+                    if (isBefore) {
+                        date > it.article.date && !isRead
+                    } else {
+                        date < it.article.date && !isRead
                     }
-                    .distinctBy { it.article.id }
+                }
+                .distinctBy { it.article.id }
 
+        if (items.isNotEmpty()) {
             diffMapHolder.updateDiff(articleWithFeed = items.toTypedArray(), markRead = true)
         }
+        return items
     }
 
     fun loadNextFeedOrGroup() {
@@ -199,15 +219,18 @@ constructor(
         }
     }
 
-    fun markAllAsRead() {
-        viewModelScope.launch {
-            val items =
-                articleListUseCase.itemSnapshotList.items
-                    .filterIsInstance<ArticleFlowItem.Article>()
-                    .map { it.articleWithFeed }
+    fun markAllAsRead(): List<ArticleWithFeed> {
+        val items =
+            articleListUseCase.itemSnapshotList.items
+                .filterIsInstance<ArticleFlowItem.Article>()
+                .map { it.articleWithFeed }
+                .filter { !diffMapHolder.checkIfRead(it) }
+                .distinctBy { it.article.id }
 
+        if (items.isNotEmpty()) {
             diffMapHolder.updateDiff(articleWithFeed = items.toTypedArray(), markRead = true)
         }
+        return items
     }
 
     fun sync() {

--- a/app/src/main/java/me/ash/reader/ui/page/adaptive/ArticleListReaderViewModel.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/adaptive/ArticleListReaderViewModel.kt
@@ -171,11 +171,12 @@ constructor(
                 )
         }
 
+    fun undoReadStatus(articleWithFeed: List<ArticleWithFeed>) {
+        diffMapHolder.applyReadStateWithSync(articleWithFeed = articleWithFeed, markRead = false)
+    }
+
     fun undoReadStatus(articleIds: Set<String>) {
-        if (articleIds.isEmpty()) return
-        applicationScope.launch(ioDispatcher) {
-            rssService.get().batchMarkAsRead(articleIds = articleIds, markRead = false)
-        }
+        diffMapHolder.applyReadStateWithSync(articleIds = articleIds, markRead = false)
     }
 
     fun updateStarredStatus(articleId: String?, isStarred: Boolean) {

--- a/app/src/main/java/me/ash/reader/ui/page/adaptive/MarkReadStatusLauncher.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/adaptive/MarkReadStatusLauncher.kt
@@ -3,6 +3,8 @@ package me.ash.reader.ui.page.adaptive
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.launch
+import me.ash.reader.domain.service.MarkReadStatusPartiallyAppliedException
+import timber.log.Timber
 
 internal fun launchMarkReadStatus(
     applicationScope: CoroutineScope,
@@ -11,6 +13,12 @@ internal fun launchMarkReadStatus(
     onMarked: (Set<String>) -> Unit = {},
 ) {
     applicationScope.launch(ioDispatcher) {
-        onMarked(markReadStatus())
+        try {
+            onMarked(markReadStatus())
+        } catch (exception: MarkReadStatusPartiallyAppliedException) {
+            Timber.tag("FlowViewModel")
+                .w(exception, "markReadStatus completed locally but remote sync failed")
+            onMarked(exception.affectedIds)
+        }
     }
 }

--- a/app/src/main/java/me/ash/reader/ui/page/adaptive/MarkReadStatusLauncher.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/adaptive/MarkReadStatusLauncher.kt
@@ -1,0 +1,16 @@
+package me.ash.reader.ui.page.adaptive
+
+import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+
+internal fun launchMarkReadStatus(
+    applicationScope: CoroutineScope,
+    ioDispatcher: CoroutineDispatcher,
+    markReadStatus: suspend () -> Set<String>,
+    onMarked: (Set<String>) -> Unit = {},
+) {
+    applicationScope.launch(ioDispatcher) {
+        onMarked(markReadStatus())
+    }
+}

--- a/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
@@ -559,13 +559,26 @@ fun FlowPage(
 
                     MarkAsReadBar {
                         markAsRead = false
+                        val preExistingLogicalReadIds =
+                            viewModel.diffMapHolder.diffMap
+                                .asSequence()
+                                .filter { it.value.isRead }
+                                .map { it.key }
+                                .toSet()
                         viewModel.markReadStatusInBackground(
                             groupId = filterUiState.group?.id,
                             feedId = filterUiState.feed?.id,
                             articleId = null,
                             conditions = it,
                             markRead = true,
-                            onMarked = showUndoSnackbarForIds,
+                            onMarked = { affectedIds ->
+                                showUndoSnackbarForIds(
+                                    filterUndoMarkedIds(
+                                        affectedIds = affectedIds,
+                                        preExistingLogicalReadIds = preExistingLogicalReadIds,
+                                    )
+                                )
+                            },
                         )
                     }
                 }

--- a/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
@@ -19,6 +19,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.WindowInsetsSides
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBars
 import androidx.compose.foundation.layout.only
@@ -41,6 +42,9 @@ import androidx.compose.material3.LargeTopAppBar
 import androidx.compose.material3.LocalContentColor
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
 import androidx.compose.material3.rememberTopAppBarState
@@ -54,6 +58,7 @@ import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.input.nestedscroll.nestedScroll
@@ -133,6 +138,8 @@ fun FlowPage(
     val sharedContent = LocalSharedContent.current
     val markAsReadOnScroll = LocalMarkAsReadOnScroll.current.value
     val context = LocalContext.current
+    val markedAsReadMessage = stringResource(R.string.marked_as_read)
+    val undoActionLabel = stringResource(R.string.undo)
 
     val openLink = LocalOpenLink.current
     val openLinkSpecificBrowser = LocalOpenLinkSpecificBrowser.current
@@ -170,6 +177,7 @@ fun FlowPage(
 
     val scope = rememberCoroutineScope()
     val focusRequester = remember { FocusRequester() }
+    val snackbarHostState = remember { SnackbarHostState() }
     var markAsRead by remember { mutableStateOf(false) }
     var onSearch by rememberSaveable { mutableStateOf(false) }
 
@@ -197,26 +205,80 @@ fun FlowPage(
         { articleWithFeed -> viewModel.diffMapHolder.updateDiff(articleWithFeed) }
     }
 
+    val showUndoSnackbarForItems: (List<ArticleWithFeed>) -> Unit =
+        remember(markedAsReadMessage, undoActionLabel) {
+            { items ->
+                if (items.isNotEmpty()) {
+                    scope.launch {
+                        val result =
+                            snackbarHostState.showSnackbar(
+                                message = markedAsReadMessage,
+                                actionLabel = undoActionLabel,
+                                withDismissAction = true,
+                            )
+                        if (result == SnackbarResult.ActionPerformed) {
+                            undoMarkedRead(
+                                items = items,
+                                deferDbCommits = viewModel.diffMapHolder.deferDbCommits,
+                                undoWithDiffMap = { articleArray ->
+                                    viewModel.diffMapHolder.updateDiff(
+                                        articleWithFeed = articleArray,
+                                        markRead = false,
+                                    )
+                                },
+                                undoWithRepository = { articleIds ->
+                                    viewModel.undoReadStatus(articleIds)
+                                },
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+    val showUndoSnackbarForIds: (Set<String>) -> Unit =
+        remember(markedAsReadMessage, undoActionLabel) {
+            { articleIds ->
+                if (articleIds.isNotEmpty()) {
+                    scope.launch {
+                        val result =
+                            snackbarHostState.showSnackbar(
+                                message = markedAsReadMessage,
+                                actionLabel = undoActionLabel,
+                                withDismissAction = true,
+                            )
+                        if (result == SnackbarResult.ActionPerformed) {
+                            viewModel.undoReadStatus(articleIds)
+                        }
+                    }
+                }
+            }
+        }
+
     val sortByEarliest =
         filterUiState.filter.isUnread() &&
             LocalSortUnreadArticles.current == SortUnreadArticlesPreference.Earliest
 
     val onMarkAboveAsRead: ((ArticleWithFeed) -> Unit)? =
-        remember(sortByEarliest) {
+        remember(sortByEarliest, showUndoSnackbarForItems) {
             {
-                viewModel.markAsReadFromListByDate(
-                    date = it.article.date,
-                    isBefore = sortByEarliest,
+                showUndoSnackbarForItems(
+                    viewModel.markAsReadFromListByDate(
+                        date = it.article.date,
+                        isBefore = sortByEarliest,
+                    )
                 )
             }
         }
 
     val onMarkBelowAsRead: ((ArticleWithFeed) -> Unit)? =
-        remember(sortByEarliest) {
+        remember(sortByEarliest, showUndoSnackbarForItems) {
             {
-                viewModel.markAsReadFromListByDate(
-                    date = it.article.date,
-                    isBefore = !sortByEarliest,
+                showUndoSnackbarForItems(
+                    viewModel.markAsReadFromListByDate(
+                        date = it.article.date,
+                        isBefore = !sortByEarliest,
+                    )
                 )
             }
         }
@@ -489,13 +551,17 @@ fun FlowPage(
 
                     MarkAsReadBar {
                         markAsRead = false
-                        viewModel.updateReadStatus(
-                            groupId = filterUiState.group?.id,
-                            feedId = filterUiState.feed?.id,
-                            articleId = null,
-                            conditions = it,
-                            markRead = true,
-                        )
+                        scope.launch {
+                            showUndoSnackbarForIds(
+                                viewModel.markReadStatus(
+                                    groupId = filterUiState.group?.id,
+                                    feedId = filterUiState.feed?.id,
+                                    articleId = null,
+                                    conditions = it,
+                                    markRead = true,
+                                )
+                            )
+                        }
                     }
                 }
                 val contentTransitionVertical =
@@ -753,5 +819,15 @@ fun FlowPage(
                         ),
             )
         }
+        SnackbarHost(
+            hostState = snackbarHostState,
+            modifier =
+                Modifier.align(Alignment.BottomCenter)
+                    .fillMaxWidth()
+                    .padding(bottom = 96.dp)
+                    .windowInsetsPadding(
+                        WindowInsets.safeContent.only(WindowInsetsSides.Horizontal)
+                    ),
+        )
     }
 }

--- a/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
@@ -559,17 +559,14 @@ fun FlowPage(
 
                     MarkAsReadBar {
                         markAsRead = false
-                        scope.launch {
-                            showUndoSnackbarForIds(
-                                viewModel.markReadStatus(
-                                    groupId = filterUiState.group?.id,
-                                    feedId = filterUiState.feed?.id,
-                                    articleId = null,
-                                    conditions = it,
-                                    markRead = true,
-                                )
-                            )
-                        }
+                        viewModel.markReadStatusInBackground(
+                            groupId = filterUiState.group?.id,
+                            feedId = filterUiState.feed?.id,
+                            articleId = null,
+                            conditions = it,
+                            markRead = true,
+                            onMarked = showUndoSnackbarForIds,
+                        )
                     }
                 }
                 val contentTransitionVertical =

--- a/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
@@ -220,15 +220,14 @@ fun FlowPage(
                         if (result == SnackbarResult.ActionPerformed) {
                             performMarkedReadUndo(
                                 action = undoAction,
-                                currentDeferDbCommits = viewModel.diffMapHolder.deferDbCommits,
                                 undoWithDiffMap = { articleArray ->
                                     viewModel.diffMapHolder.updateDiff(
                                         articleWithFeed = articleArray,
                                         markRead = false,
                                     )
                                 },
-                                undoWithRepository = { articleIds ->
-                                    viewModel.undoReadStatus(articleIds)
+                                undoWithCommittedState = { articleWithFeed ->
+                                    viewModel.undoReadStatus(articleWithFeed)
                                 },
                             )
                         }

--- a/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
@@ -205,9 +205,10 @@ fun FlowPage(
         { articleWithFeed -> viewModel.diffMapHolder.updateDiff(articleWithFeed) }
     }
 
-    val showUndoSnackbarForItems: (List<ArticleWithFeed>) -> Unit =
+    val showUndoSnackbarForItems: (MarkedReadUndoAction) -> Unit =
         remember(markedAsReadMessage, undoActionLabel) {
-            { items ->
+            { undoAction ->
+                val items = undoAction.items
                 if (items.isNotEmpty()) {
                     scope.launch {
                         val result =
@@ -217,9 +218,9 @@ fun FlowPage(
                                 withDismissAction = true,
                             )
                         if (result == SnackbarResult.ActionPerformed) {
-                            undoMarkedRead(
-                                items = items,
-                                deferDbCommits = viewModel.diffMapHolder.deferDbCommits,
+                            performMarkedReadUndo(
+                                action = undoAction,
+                                currentDeferDbCommits = viewModel.diffMapHolder.deferDbCommits,
                                 undoWithDiffMap = { articleArray ->
                                     viewModel.diffMapHolder.updateDiff(
                                         articleWithFeed = articleArray,
@@ -263,9 +264,13 @@ fun FlowPage(
         remember(sortByEarliest, showUndoSnackbarForItems) {
             {
                 showUndoSnackbarForItems(
-                    viewModel.markAsReadFromListByDate(
-                        date = it.article.date,
-                        isBefore = sortByEarliest,
+                    createMarkedReadUndoAction(
+                        items =
+                            viewModel.markAsReadFromListByDate(
+                                date = it.article.date,
+                                isBefore = sortByEarliest,
+                            ),
+                        deferDbCommits = viewModel.diffMapHolder.deferDbCommits,
                     )
                 )
             }
@@ -275,9 +280,13 @@ fun FlowPage(
         remember(sortByEarliest, showUndoSnackbarForItems) {
             {
                 showUndoSnackbarForItems(
-                    viewModel.markAsReadFromListByDate(
-                        date = it.article.date,
-                        isBefore = !sortByEarliest,
+                    createMarkedReadUndoAction(
+                        items =
+                            viewModel.markAsReadFromListByDate(
+                                date = it.article.date,
+                                isBefore = !sortByEarliest,
+                            ),
+                        deferDbCommits = viewModel.diffMapHolder.deferDbCommits,
                     )
                 )
             }

--- a/app/src/main/java/me/ash/reader/ui/page/home/flow/UndoMarkedRead.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/flow/UndoMarkedRead.kt
@@ -2,6 +2,31 @@ package me.ash.reader.ui.page.home.flow
 
 import me.ash.reader.domain.model.article.ArticleWithFeed
 
+internal data class MarkedReadUndoAction(
+    val items: List<ArticleWithFeed>,
+    val deferDbCommitsAtMarkTime: Boolean,
+)
+
+internal fun createMarkedReadUndoAction(
+    items: List<ArticleWithFeed>,
+    deferDbCommits: Boolean,
+): MarkedReadUndoAction = MarkedReadUndoAction(items, deferDbCommits)
+
+internal fun performMarkedReadUndo(
+    action: MarkedReadUndoAction,
+    currentDeferDbCommits: Boolean,
+    undoWithDiffMap: (Array<ArticleWithFeed>) -> Unit,
+    undoWithRepository: (Set<String>) -> Unit,
+) {
+    // Intentionally use the captured mode from mark-time, not current mode.
+    undoMarkedRead(
+        items = action.items,
+        deferDbCommits = action.deferDbCommitsAtMarkTime,
+        undoWithDiffMap = undoWithDiffMap,
+        undoWithRepository = undoWithRepository,
+    )
+}
+
 internal fun undoMarkedRead(
     items: List<ArticleWithFeed>,
     deferDbCommits: Boolean,

--- a/app/src/main/java/me/ash/reader/ui/page/home/flow/UndoMarkedRead.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/flow/UndoMarkedRead.kt
@@ -1,0 +1,17 @@
+package me.ash.reader.ui.page.home.flow
+
+import me.ash.reader.domain.model.article.ArticleWithFeed
+
+internal fun undoMarkedRead(
+    items: List<ArticleWithFeed>,
+    deferDbCommits: Boolean,
+    undoWithDiffMap: (Array<ArticleWithFeed>) -> Unit,
+    undoWithRepository: (Set<String>) -> Unit,
+) {
+    if (items.isEmpty()) return
+    if (deferDbCommits) {
+        undoWithDiffMap(items.toTypedArray())
+    } else {
+        undoWithRepository(items.map { it.article.id }.toSet())
+    }
+}

--- a/app/src/main/java/me/ash/reader/ui/page/home/flow/UndoMarkedRead.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/flow/UndoMarkedRead.kt
@@ -14,16 +14,15 @@ internal fun createMarkedReadUndoAction(
 
 internal fun performMarkedReadUndo(
     action: MarkedReadUndoAction,
-    currentDeferDbCommits: Boolean,
     undoWithDiffMap: (Array<ArticleWithFeed>) -> Unit,
-    undoWithRepository: (Set<String>) -> Unit,
+    undoWithCommittedState: (List<ArticleWithFeed>) -> Unit,
 ) {
     // Intentionally use the captured mode from mark-time, not current mode.
     undoMarkedRead(
         items = action.items,
         deferDbCommits = action.deferDbCommitsAtMarkTime,
         undoWithDiffMap = undoWithDiffMap,
-        undoWithRepository = undoWithRepository,
+        undoWithCommittedState = undoWithCommittedState,
     )
 }
 
@@ -31,12 +30,12 @@ internal fun undoMarkedRead(
     items: List<ArticleWithFeed>,
     deferDbCommits: Boolean,
     undoWithDiffMap: (Array<ArticleWithFeed>) -> Unit,
-    undoWithRepository: (Set<String>) -> Unit,
+    undoWithCommittedState: (List<ArticleWithFeed>) -> Unit,
 ) {
     if (items.isEmpty()) return
     if (deferDbCommits) {
         undoWithDiffMap(items.toTypedArray())
     } else {
-        undoWithRepository(items.map { it.article.id }.toSet())
+        undoWithCommittedState(items.distinctBy { it.article.id })
     }
 }

--- a/app/src/main/java/me/ash/reader/ui/page/home/flow/UndoMarkedRead.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/flow/UndoMarkedRead.kt
@@ -39,3 +39,8 @@ internal fun undoMarkedRead(
         undoWithCommittedState(items.distinctBy { it.article.id })
     }
 }
+
+internal fun filterUndoMarkedIds(
+    affectedIds: Set<String>,
+    preExistingLogicalReadIds: Set<String>,
+): Set<String> = affectedIds - preExistingLogicalReadIds

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -323,6 +323,8 @@
     <string name="pull_to_switch_article">Pull to switch article</string>
     <string name="mark_above_as_read">Mark above as read</string>
     <string name="mark_below_as_read">Mark below as read</string>
+    <string name="marked_as_read">Marked as read</string>
+    <string name="undo">Undo</string>
     <string name="save">Save</string>
     <string name="image_saved">Image saved</string>
     <string name="permission_denied">Permission denied</string>

--- a/app/src/test/java/me/ash/reader/domain/data/DiffMapHolderUpdateDiffTest.kt
+++ b/app/src/test/java/me/ash/reader/domain/data/DiffMapHolderUpdateDiffTest.kt
@@ -276,6 +276,31 @@ class DiffMapHolderUpdateDiffTest {
         )
     }
 
+    @Test
+    fun `explicit unread undo by ids participates in remote sync`() = runBlocking {
+        val pendingReadStateOpDao = pendingReadStateOpDao()
+        val rssRepository = mock<AbstractRssRepository>()
+        whenever(rssRepository.syncReadStatus(emptySet(), true)).thenReturn(emptySet())
+        whenever(rssRepository.syncReadStatus(setOf("article"), false)).thenReturn(setOf("article"))
+
+        val holder = createHolder(
+            account = Account(
+                id = 1,
+                name = "FreshRSS",
+                type = AccountType(AccountType.FreshRSS.id),
+            ),
+            pendingReadStateOpDao = pendingReadStateOpDao,
+            rssRepository = rssRepository,
+            deferDbCommits = false,
+        )
+
+        holder.applyReadStateWithSync(setOf("article"), markRead = false)
+        holder.prepareReadStateForSync(1)
+
+        verify(rssRepository).batchMarkAsRead(setOf("article"), markRead = false)
+        verify(rssRepository).syncReadStatus(setOf("article"), false)
+    }
+
     private fun createHolder(
         account: Account = Account(
             id = 1,

--- a/app/src/test/java/me/ash/reader/ui/page/adaptive/MarkReadStatusLauncherTest.kt
+++ b/app/src/test/java/me/ash/reader/ui/page/adaptive/MarkReadStatusLauncherTest.kt
@@ -9,6 +9,7 @@ import kotlinx.coroutines.awaitCancellation
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
+import me.ash.reader.domain.service.MarkReadStatusPartiallyAppliedException
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
@@ -42,6 +43,33 @@ class MarkReadStatusLauncherTest {
 
         assertTrue(started.await(2, TimeUnit.SECONDS))
         callerScope.cancel()
+
+        assertTrue(latch.await(2, TimeUnit.SECONDS))
+        assertEquals(setOf("article"), markedIds)
+
+        applicationScope.cancel()
+    }
+
+    @Test
+    fun `onMarked still runs when mark-read was applied locally before remote failure`() {
+        val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val latch = CountDownLatch(1)
+        var markedIds: Set<String> = emptySet()
+
+        launchMarkReadStatus(
+            applicationScope = applicationScope,
+            ioDispatcher = Dispatchers.Default,
+            markReadStatus = {
+                throw MarkReadStatusPartiallyAppliedException(
+                    affectedIds = setOf("article"),
+                    cause = IllegalStateException("remote failed"),
+                )
+            },
+            onMarked = {
+                markedIds = it
+                latch.countDown()
+            },
+        )
 
         assertTrue(latch.await(2, TimeUnit.SECONDS))
         assertEquals(setOf("article"), markedIds)

--- a/app/src/test/java/me/ash/reader/ui/page/adaptive/MarkReadStatusLauncherTest.kt
+++ b/app/src/test/java/me/ash/reader/ui/page/adaptive/MarkReadStatusLauncherTest.kt
@@ -1,0 +1,51 @@
+package me.ash.reader.ui.page.adaptive
+
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class MarkReadStatusLauncherTest {
+
+    @Test
+    fun `mark-read work survives caller scope cancellation`() {
+        val applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val callerScope = CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        val started = CountDownLatch(1)
+        val latch = CountDownLatch(1)
+        var markedIds: Set<String> = emptySet()
+
+        callerScope.launch {
+            launchMarkReadStatus(
+                applicationScope = applicationScope,
+                ioDispatcher = Dispatchers.Default,
+                markReadStatus = {
+                    delay(100)
+                    setOf("article")
+                },
+                onMarked = {
+                    markedIds = it
+                    latch.countDown()
+                },
+            )
+            started.countDown()
+            awaitCancellation()
+        }
+
+        assertTrue(started.await(2, TimeUnit.SECONDS))
+        callerScope.cancel()
+
+        assertTrue(latch.await(2, TimeUnit.SECONDS))
+        assertEquals(setOf("article"), markedIds)
+
+        applicationScope.cancel()
+    }
+}

--- a/app/src/test/java/me/ash/reader/ui/page/home/flow/UndoMarkedReadTest.kt
+++ b/app/src/test/java/me/ash/reader/ui/page/home/flow/UndoMarkedReadTest.kt
@@ -71,6 +71,17 @@ class UndoMarkedReadTest {
         assertEquals(listOf("a", "b"), committedItems.map { it.article.id })
     }
 
+    @Test
+    fun `filters out articles that were already logically read before mark action`() {
+        val undoIds =
+            filterUndoMarkedIds(
+                affectedIds = setOf("a", "b", "c"),
+                preExistingLogicalReadIds = setOf("b"),
+            )
+
+        assertEquals(setOf("a", "c"), undoIds)
+    }
+
     private fun unreadArticle(id: String): ArticleWithFeed =
         ArticleWithFeed(
             article =

--- a/app/src/test/java/me/ash/reader/ui/page/home/flow/UndoMarkedReadTest.kt
+++ b/app/src/test/java/me/ash/reader/ui/page/home/flow/UndoMarkedReadTest.kt
@@ -14,7 +14,7 @@ class UndoMarkedReadTest {
     fun `uses diff-map undo when commits are deferred`() {
         val items = listOf(unreadArticle("a"), unreadArticle("b"))
         var diffUndoCalled = false
-        var repoUndoCalled = false
+        var committedUndoCalled = false
 
         undoMarkedRead(
             items = items,
@@ -23,21 +23,21 @@ class UndoMarkedReadTest {
                 diffUndoCalled = true
                 assertEquals(2, it.size)
             },
-            undoWithRepository = {
-                repoUndoCalled = true
+            undoWithCommittedState = {
+                committedUndoCalled = true
             },
         )
 
         assertTrue(diffUndoCalled)
-        assertEquals(false, repoUndoCalled)
+        assertEquals(false, committedUndoCalled)
     }
 
     @Test
-    fun `uses repository undo with deduped ids when commits are immediate`() {
+    fun `uses committed-state undo with deduped items when commits are immediate`() {
         val duplicate = unreadArticle("a")
         val items = listOf(duplicate, duplicate, unreadArticle("b"))
         var diffUndoCalled = false
-        var repoIds: Set<String> = emptySet()
+        var committedItems: List<ArticleWithFeed> = emptyList()
 
         undoMarkedRead(
             items = items,
@@ -45,13 +45,13 @@ class UndoMarkedReadTest {
             undoWithDiffMap = {
                 diffUndoCalled = true
             },
-            undoWithRepository = { ids ->
-                repoIds = ids
+            undoWithCommittedState = {
+                committedItems = it
             },
         )
 
         assertEquals(false, diffUndoCalled)
-        assertEquals(setOf("a", "b"), repoIds)
+        assertEquals(listOf("a", "b"), committedItems.map { it.article.id })
     }
 
     @Test
@@ -59,18 +59,16 @@ class UndoMarkedReadTest {
         val items = listOf(unreadArticle("a"), unreadArticle("b"))
         val action = createMarkedReadUndoAction(items, deferDbCommits = false)
         var diffUndoCalled = false
-        var repoIds: Set<String> = emptySet()
+        var committedItems: List<ArticleWithFeed> = emptyList()
 
-        // Simulate filter changed before undo is clicked (current mode now deferred=true).
         performMarkedReadUndo(
             action = action,
-            currentDeferDbCommits = true,
             undoWithDiffMap = { diffUndoCalled = true },
-            undoWithRepository = { ids -> repoIds = ids },
+            undoWithCommittedState = { committedItems = it },
         )
 
         assertEquals(false, diffUndoCalled)
-        assertEquals(setOf("a", "b"), repoIds)
+        assertEquals(listOf("a", "b"), committedItems.map { it.article.id })
     }
 
     private fun unreadArticle(id: String): ArticleWithFeed =

--- a/app/src/test/java/me/ash/reader/ui/page/home/flow/UndoMarkedReadTest.kt
+++ b/app/src/test/java/me/ash/reader/ui/page/home/flow/UndoMarkedReadTest.kt
@@ -1,0 +1,80 @@
+package me.ash.reader.ui.page.home.flow
+
+import java.util.Date
+import me.ash.reader.domain.model.article.Article
+import me.ash.reader.domain.model.article.ArticleWithFeed
+import me.ash.reader.domain.model.feed.Feed
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+class UndoMarkedReadTest {
+
+    @Test
+    fun `uses diff-map undo when commits are deferred`() {
+        val items = listOf(unreadArticle("a"), unreadArticle("b"))
+        var diffUndoCalled = false
+        var repoUndoCalled = false
+
+        undoMarkedRead(
+            items = items,
+            deferDbCommits = true,
+            undoWithDiffMap = {
+                diffUndoCalled = true
+                assertEquals(2, it.size)
+            },
+            undoWithRepository = {
+                repoUndoCalled = true
+            },
+        )
+
+        assertTrue(diffUndoCalled)
+        assertEquals(false, repoUndoCalled)
+    }
+
+    @Test
+    fun `uses repository undo with deduped ids when commits are immediate`() {
+        val duplicate = unreadArticle("a")
+        val items = listOf(duplicate, duplicate, unreadArticle("b"))
+        var diffUndoCalled = false
+        var repoIds: Set<String> = emptySet()
+
+        undoMarkedRead(
+            items = items,
+            deferDbCommits = false,
+            undoWithDiffMap = {
+                diffUndoCalled = true
+            },
+            undoWithRepository = { ids ->
+                repoIds = ids
+            },
+        )
+
+        assertEquals(false, diffUndoCalled)
+        assertEquals(setOf("a", "b"), repoIds)
+    }
+
+    private fun unreadArticle(id: String): ArticleWithFeed =
+        ArticleWithFeed(
+            article =
+                Article(
+                    id = id,
+                    date = Date(0L),
+                    title = "Article",
+                    rawDescription = "<p>Article</p>",
+                    shortDescription = "Article",
+                    link = "https://example.com/article/$id",
+                    feedId = "feed",
+                    accountId = 1,
+                    isUnread = true,
+                ),
+            feed =
+                Feed(
+                    id = "feed",
+                    name = "Feed",
+                    url = "https://example.com/feed",
+                    groupId = "group",
+                    accountId = 1,
+                ),
+        )
+}

--- a/app/src/test/java/me/ash/reader/ui/page/home/flow/UndoMarkedReadTest.kt
+++ b/app/src/test/java/me/ash/reader/ui/page/home/flow/UndoMarkedReadTest.kt
@@ -54,6 +54,25 @@ class UndoMarkedReadTest {
         assertEquals(setOf("a", "b"), repoIds)
     }
 
+    @Test
+    fun `undo action uses captured mode instead of current mode`() {
+        val items = listOf(unreadArticle("a"), unreadArticle("b"))
+        val action = createMarkedReadUndoAction(items, deferDbCommits = false)
+        var diffUndoCalled = false
+        var repoIds: Set<String> = emptySet()
+
+        // Simulate filter changed before undo is clicked (current mode now deferred=true).
+        performMarkedReadUndo(
+            action = action,
+            currentDeferDbCommits = true,
+            undoWithDiffMap = { diffUndoCalled = true },
+            undoWithRepository = { ids -> repoIds = ids },
+        )
+
+        assertEquals(false, diffUndoCalled)
+        assertEquals(setOf("a", "b"), repoIds)
+    }
+
     private fun unreadArticle(id: String): ArticleWithFeed =
         ArticleWithFeed(
             article =


### PR DESCRIPTION
## Summary
- add undo snackbar support for mark-all and mark above/below read actions
- make undo path reliable in All filter by routing undo through repository IDs when DB commits are immediate
- keep diff-map undo path for deferred commits in Unread filter
- keep pull-to-load mark-all intentionally without undo snackbar

## Testing
- ./gradlew :app:testGithubDebugUnitTest --tests "me.ash.reader.ui.page.home.flow.UndoMarkedReadTest"
- ./gradlew :app:compileGithubDebugKotlin

Closes #78