### PR TITLE
fix: keep embedded video fullscreen active on rotation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -50,6 +50,7 @@
         </activity>
         <activity
             android:name=".infrastructure.android.MainActivity"
+            android:configChanges="keyboardHidden|orientation|screenLayout|screenSize|smallestScreenSize"
             android:exported="true"
             android:launchMode="singleInstance"
             android:theme="@style/Theme.Reader"

--- a/app/src/main/java/me/ash/reader/ui/component/webview/RYWebView.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/RYWebView.kt
@@ -13,10 +13,10 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.toArgb
-import androidx.compose.ui.platform.LocalConfiguration
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -52,6 +52,7 @@ class HorizontalScrollAwareWebView(context: Context) : WebView(context) {
     private var startY = 0f
     private var isHorizontalGesture: Boolean? = null
     private val touchSlop = ViewConfiguration.get(context).scaledTouchSlop.toFloat()
+    var loadedContentKey: WebViewContentKey? = null
 
     @SuppressLint("ClickableViewAccessibility")
     override fun dispatchTouchEvent(event: MotionEvent): Boolean {
@@ -82,6 +83,8 @@ class HorizontalScrollAwareWebView(context: Context) : WebView(context) {
     }
 }
 
+data class WebViewContentKey(val baseUrl: String, val html: String, val fontSize: Int)
+
 @Composable
 fun RYWebView(
     modifier: Modifier = Modifier,
@@ -94,7 +97,6 @@ fun RYWebView(
     onHideCustomView: (() -> Unit)? = null,
 ) {
     val context = LocalContext.current
-    val maxWidth = LocalConfiguration.current.screenWidthDp.dp.value
     val openLink = LocalOpenLink.current
     val openLinkSpecificBrowser = LocalOpenLinkSpecificBrowser.current
     val tonalElevation = LocalReadingPageTonalElevation.current
@@ -121,17 +123,22 @@ fun RYWebView(
         MaterialTheme.colorScheme.surfaceColorAtElevation((tonalElevation.value + 6).dp).toArgb()
     val boldCharacters = LocalReadingBoldCharacters.current
 
-    val webChromeClient = remember(onShowCustomView, onHideCustomView) {
-        if (onShowCustomView != null && onHideCustomView != null) {
+    val currentOnShowCustomView by rememberUpdatedState(onShowCustomView)
+    val currentOnHideCustomView by rememberUpdatedState(onHideCustomView)
+    val hasCustomViewCallbacks = onShowCustomView != null && onHideCustomView != null
+    val webChromeClient = remember(hasCustomViewCallbacks) {
+        if (hasCustomViewCallbacks) {
             RYWebChromeClient(
-                onShowCustomViewCallback = onShowCustomView,
-                onHideCustomViewCallback = onHideCustomView,
+                onShowCustomViewCallback = { view, callback ->
+                    currentOnShowCustomView?.invoke(view, callback) ?: callback.onCustomViewHidden()
+                },
+                onHideCustomViewCallback = { currentOnHideCustomView?.invoke() },
             )
         } else null
     }
 
     val webView by
-        remember(backgroundColor, webChromeClient) {
+        remember(context, readingFonts, refererDomain, openLink, openLinkSpecificBrowser, webChromeClient) {
             mutableStateOf(
                 WebViewLayout.get(
                     context = context,
@@ -163,12 +170,8 @@ fun RYWebView(
         modifier = modifier,
         factory = { webView },
         update = { wv ->
-                Timber.tag("RLog").i("maxWidth: ${maxWidth}")
-                Timber.tag("RLog").i("readingFont: ${context.filesDir.absolutePath}")
-                Timber.tag("RLog").i("CustomWebView: ${content}")
             wv.settings.defaultFontSize = fontSize
-            wv.loadDataWithBaseURL(
-                htmlBaseUrl,
+            val html =
                 WebViewHtml.HTML.format(
                     WebViewStyle.get(
                         fontSize = fontSize,
@@ -194,11 +197,20 @@ fun RYWebView(
                     htmlBaseUrl,
                     content,
                     WebViewScript.get(boldCharacters.value),
-                ),
-                "text/HTML",
-                "UTF-8",
-                null,
-            )
+                )
+            val contentKey = WebViewContentKey(htmlBaseUrl, html, fontSize)
+            if (wv.loadedContentKey != contentKey) {
+                Timber.tag("RLog").i("readingFont: ${context.filesDir.absolutePath}")
+                Timber.tag("RLog").i("CustomWebView: ${content}")
+                wv.loadedContentKey = contentKey
+                wv.loadDataWithBaseURL(
+                    htmlBaseUrl,
+                    html,
+                    "text/HTML",
+                    "UTF-8",
+                    null,
+                )
+            }
         },
     )
 }

--- a/app/src/main/java/me/ash/reader/ui/component/webview/RYWebView.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/RYWebView.kt
@@ -185,9 +185,20 @@ fun RYWebView(
         modifier = modifier,
         factory = { webView },
         update = { wv ->
+            if (wv.webViewClient !== dynamicWebViewClient) {
+                wv.webViewClient = dynamicWebViewClient
+            }
             wv.webChromeClient =
                 if (onShowCustomView != null && onHideCustomView != null) webChromeClient else null
             wv.settings.defaultFontSize = fontSize
+            wv.settings.standardFontFamily =
+                when (readingFonts) {
+                    ReadingFontsPreference.Cursive -> "cursive"
+                    ReadingFontsPreference.Monospace -> "monospace"
+                    ReadingFontsPreference.SansSerif -> "sans-serif"
+                    ReadingFontsPreference.Serif -> "serif"
+                    else -> "sans-serif"
+                }
             val html =
                 WebViewHtml.HTML.format(
                     WebViewStyle.get(

--- a/app/src/main/java/me/ash/reader/ui/component/webview/RYWebView.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/RYWebView.kt
@@ -128,6 +128,18 @@ fun RYWebView(
     val boldCharacters = LocalReadingBoldCharacters.current
     val onWebViewCreatedForTest = LocalWebViewCreatedForTest.current
 
+    val currentOpenLink by rememberUpdatedState(openLink)
+    val currentOpenLinkSpecificBrowser by rememberUpdatedState(openLinkSpecificBrowser)
+    val dynamicWebViewClient = remember(context, refererDomain) {
+        WebViewClient(
+            context = context,
+            refererDomain = refererDomain,
+            onOpenLink = { url ->
+                context.openURL(url, currentOpenLink, currentOpenLinkSpecificBrowser)
+            },
+        )
+    }
+
     val onShowCustomViewState by rememberUpdatedState(onShowCustomView)
     val onHideCustomViewState by rememberUpdatedState(onHideCustomView)
     val webChromeClient = remember {
@@ -147,14 +159,7 @@ fun RYWebView(
                 WebViewLayout.get(
                     context = context,
                     readingFontsPreference = readingFonts,
-                    webViewClient =
-                        WebViewClient(
-                            context = context,
-                            refererDomain = refererDomain,
-                            onOpenLink = { url ->
-                                context.openURL(url, openLink, openLinkSpecificBrowser)
-                            },
-                        ),
+                    webViewClient = dynamicWebViewClient,
                     webChromeClient = null,
                     onImageClick = onImageClick,
                     onLinkLongPress = onLinkLongPress,

--- a/app/src/main/java/me/ash/reader/ui/page/home/reading/ReadingPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/reading/ReadingPage.kt
@@ -82,8 +82,17 @@ fun ReadingPage(
     val isPullToSwitchArticleEnabled = LocalPullToSwitchArticle.current.value
     val readingUiState = viewModel.readingUiState.collectAsStateValue()
     val readerState = viewModel.readerStateStateFlow.collectAsStateValue()
+    val contentStateKey =
+        when (readerState.content) {
+            is ReaderState.Description -> "description"
+            is ReaderState.FullContent -> "full_content"
+            is ReaderState.Error -> "error"
+            ReaderState.Loading -> "loading"
+        }
     val scrollState =
-        rememberSaveable(readerState.articleId, saver = ScrollState.Saver) { ScrollState(0) }
+        rememberSaveable(readerState.articleId, contentStateKey, saver = ScrollState.Saver) {
+            ScrollState(0)
+        }
 
     var isReaderScrollingDown by remember { mutableStateOf(false) }
     var showFullScreenImageViewer by remember { mutableStateOf(false) }

--- a/app/src/main/java/me/ash/reader/ui/page/home/reading/ReadingPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/reading/ReadingPage.kt
@@ -16,10 +16,10 @@ import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.ScrollState
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.rememberScrollState
 import androidx.compose.material.ExperimentalMaterialApi
 import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
@@ -32,6 +32,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
@@ -81,6 +82,8 @@ fun ReadingPage(
     val isPullToSwitchArticleEnabled = LocalPullToSwitchArticle.current.value
     val readingUiState = viewModel.readingUiState.collectAsStateValue()
     val readerState = viewModel.readerStateStateFlow.collectAsStateValue()
+    val scrollState =
+        rememberSaveable(readerState.articleId, saver = ScrollState.Saver) { ScrollState(0) }
 
     var isReaderScrollingDown by remember { mutableStateOf(false) }
     var showFullScreenImageViewer by remember { mutableStateOf(false) }
@@ -225,8 +228,6 @@ fun ReadingPage(
                                                 }
                                             } else null,
                                     )
-
-                                val scrollState = rememberScrollState()
 
                                 val scope = rememberCoroutineScope()
 


### PR DESCRIPTION
## Summary
- prevent activity recreation on orientation/screen-size changes for MainActivity
- make RYWebView instance stable across recompositions and only reload HTML when content key changes
- persist reading scroll state per article in ReadingPage

## Why
Issue #68 reports that rotating during embedded video fullscreen recreates the reader and closes the player. This keeps the fullscreen session alive through rotation.

Closes #68.

## Follow-up (separate issue)
Fullscreen exit can shift scroll near article bottom due to WebView scroll-range shrink and clamp behavior.
Tracked in #82.
