### PR TITLE
chore: add AGENTS.md install targeting guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,10 @@
+# AGENTS
+
+## Android Install Safety Rule
+
+When developing or testing this project, do **not** install builds to all connected devices by default.
+
+- Prefer installing to an emulator only.
+- Do **not** install to a physical device unless the user explicitly asks for it.
+- Before running install commands, ensure the target device is specified (for example, via `adb -s <serial> ...`) or that only the intended emulator is connected.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,5 +6,5 @@ When developing or testing this project, do **not** install builds to all connec
 
 - Prefer installing to an emulator only.
 - Do **not** install to a physical device unless the user explicitly asks for it.
-- Before running install commands, ensure the target device is specified (for example, via `adb -s <serial> ...`) or that only the intended emulator is connected.
+- Before running install commands, ensure the target device is specified (for example, via the `ANDROID_SERIAL` environment variable or `adb -s <serial> ...`) or that only the intended emulator is connected.
 


### PR DESCRIPTION
## Summary
- add AGENTS.md with repo-level guidance for Android install behavior during development
- require targeted emulator installs by default
- avoid installing to physical devices unless explicitly requested
