### PR TITLE
[codex] fix inline callouts in reading WebView

### DIFF
--- a/app/src/androidTest/java/me/ash/reader/ui/component/webview/RYWebViewTableTest.kt
+++ b/app/src/androidTest/java/me/ash/reader/ui/component/webview/RYWebViewTableTest.kt
@@ -123,6 +123,27 @@ class RYWebViewTableTest {
         assertEquals("rgb(17, 17, 17)", metrics.getString("nestedHeaderColor"))
     }
 
+    @Test
+    fun inlineLinksInsideDivCalloutsRemainInline() {
+        loadArticle(CALLOUT_HTML)
+
+        val metrics = evaluateJavascript(
+            """
+            (function() {
+                const callout = document.querySelector('.kg-callout-text');
+                const link = callout.querySelector('a');
+                return JSON.stringify({
+                    calloutDisplay: getComputedStyle(callout).display,
+                    linkDisplay: getComputedStyle(link).display
+                });
+            })()
+            """.trimIndent()
+        )
+
+        assertEquals("block", metrics.getString("calloutDisplay"))
+        assertEquals("inline", metrics.getString("linkDisplay"))
+    }
+
     private fun loadArticle(content: String) {
         val pageLoaded = CountDownLatch(1)
         val html = WebViewHtml.HTML.format(
@@ -255,6 +276,19 @@ class RYWebViewTableTest {
                     </td>
                 </tr>
             </table>
+        """
+
+        const val CALLOUT_HTML = """
+            <div class="kg-card kg-callout-card kg-callout-card-blue">
+                <div class="kg-callout-emoji">💡</div>
+                <div class="kg-callout-text">
+                    <b><strong style="white-space: pre-wrap;">TIP:</strong></b>
+                    If you are looking for a personal VPN, you should get one that has a verified
+                    <a href="https://example.com/no-logs">no-logs policy</a>,
+                    a large <a href="https://example.com/network">server network</a>,
+                    and modern <a href="https://example.com/protocols">protocols</a>.
+                </div>
+            </div>
         """
     }
 }

--- a/app/src/main/java/me/ash/reader/ui/component/webview/WebViewStyle.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/WebViewStyle.kt
@@ -149,15 +149,6 @@ a > strong {
     font-weight: 600 !important;
     color: var(--link-text-color) !important;
 }
-/* Keep links inside feed-provided callout/div content inline. */
-div > a {
-    -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
-    font-weight: 600 !important;
-    color: var(--link-text-color);
-    line-height: var(--line-height);
-    letter-spacing: var(--letter-spacing) !important;
-    text-align: var(--text-align) !important;
-}
 
 /* Image  */
 iframe,

--- a/app/src/main/java/me/ash/reader/ui/component/webview/WebViewStyle.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/WebViewStyle.kt
@@ -149,8 +149,8 @@ a > strong {
     font-weight: 600 !important;
     color: var(--link-text-color) !important;
 }
+/* Keep links inside feed-provided callout/div content inline. */
 div > a {
-    display: block;
     -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
     font-weight: 600 !important;
     color: var(--link-text-color);


### PR DESCRIPTION
## Summary

- Removed the overly broad `div > a { display: block; }` rule from the WebView stylesheet so inline links inside feed-provided callouts stay inline.
- Added an instrumentation regression test that checks links inside `.kg-callout-text` compute to `display: inline`.

## Validation

- `ANDROID_SERIAL=emulator-5554 ./gradlew :app:connectedGithubDebugAndroidTest -Pandroid.testInstrumentationRunnerArguments.class=me.ash.reader.ui.component.webview.RYWebViewTableTest#inlineLinksInsideDivCalloutsRemainInline`

Closes #87
