### PR TITLE
fix(flow): mark above/below by list position

### DIFF
--- a/app/src/main/java/me/ash/reader/ui/page/adaptive/ArticleListReaderViewModel.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/adaptive/ArticleListReaderViewModel.kt
@@ -475,9 +475,9 @@ internal fun selectArticlesToMark(
 
     val relativeArticles =
         if (markAbove) {
-            articles.take(targetIndex)
+            articles.subList(0, targetIndex)
         } else {
-            articles.drop(targetIndex + 1)
+            articles.subList(targetIndex + 1, articles.size)
         }
 
     return relativeArticles.filter { !it.article.isRead }.distinctBy { it.article.id }

--- a/app/src/main/java/me/ash/reader/ui/page/adaptive/ArticleListReaderViewModel.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/adaptive/ArticleListReaderViewModel.kt
@@ -168,20 +168,13 @@ constructor(
         }
     }
 
-    fun markAsReadFromListByDate(date: Date, isBefore: Boolean) {
+    fun markAsReadFromListPosition(articleId: String, markAbove: Boolean) {
         viewModelScope.launch(ioDispatcher) {
-            val items =
-                articleListUseCase.itemSnapshotList
-                    .filterIsInstance<ArticleFlowItem.Article>()
-                    .map { it.articleWithFeed }
-                    .filter {
-                        if (isBefore) {
-                            date > it.article.date && !it.article.isRead
-                        } else {
-                            date < it.article.date && !it.article.isRead
-                        }
-                    }
-                    .distinctBy { it.article.id }
+            val items = selectArticlesToMark(
+                items = articleListUseCase.itemSnapshotList.items,
+                targetArticleId = articleId,
+                markAbove = markAbove,
+            )
 
             diffMapHolder.updateDiff(articleWithFeed = items.toTypedArray(), markRead = true)
         }
@@ -470,6 +463,25 @@ constructor(
 }
 
 data class FlowUiState(val pagerData: PagerData, val nextFilterState: FilterState? = null)
+
+internal fun selectArticlesToMark(
+    items: Iterable<ArticleFlowItem>,
+    targetArticleId: String,
+    markAbove: Boolean,
+): List<ArticleWithFeed> {
+    val articles = items.filterIsInstance<ArticleFlowItem.Article>().map { it.articleWithFeed }
+    val targetIndex = articles.indexOfFirst { it.article.id == targetArticleId }
+    if (targetIndex == -1) return emptyList()
+
+    val relativeArticles =
+        if (markAbove) {
+            articles.take(targetIndex)
+        } else {
+            articles.drop(targetIndex + 1)
+        }
+
+    return relativeArticles.filter { !it.article.isRead }.distinctBy { it.article.id }
+}
 
 data class ReadingUiState(
     val articleWithFeed: ArticleWithFeed? = null,

--- a/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
@@ -86,9 +86,7 @@ import me.ash.reader.infrastructure.preference.LocalOpenLink
 import me.ash.reader.infrastructure.preference.LocalOpenLinkSpecificBrowser
 import me.ash.reader.infrastructure.preference.LocalSettings
 import me.ash.reader.infrastructure.preference.LocalSharedContent
-import me.ash.reader.infrastructure.preference.LocalSortUnreadArticles
 import me.ash.reader.infrastructure.preference.PullToLoadNextFeedPreference
-import me.ash.reader.infrastructure.preference.SortUnreadArticlesPreference
 import me.ash.reader.ui.component.FilterBar
 import me.ash.reader.ui.component.base.FeedbackIconButton
 import me.ash.reader.ui.component.base.RYExtensibleVisibility
@@ -197,26 +195,22 @@ fun FlowPage(
         { articleWithFeed -> viewModel.diffMapHolder.updateDiff(articleWithFeed) }
     }
 
-    val sortByEarliest =
-        filterUiState.filter.isUnread() &&
-            LocalSortUnreadArticles.current == SortUnreadArticlesPreference.Earliest
-
     val onMarkAboveAsRead: ((ArticleWithFeed) -> Unit)? =
-        remember(sortByEarliest) {
+        remember {
             {
-                viewModel.markAsReadFromListByDate(
-                    date = it.article.date,
-                    isBefore = sortByEarliest,
+                viewModel.markAsReadFromListPosition(
+                    articleId = it.article.id,
+                    markAbove = true,
                 )
             }
         }
 
     val onMarkBelowAsRead: ((ArticleWithFeed) -> Unit)? =
-        remember(sortByEarliest) {
+        remember {
             {
-                viewModel.markAsReadFromListByDate(
-                    date = it.article.date,
-                    isBefore = !sortByEarliest,
+                viewModel.markAsReadFromListPosition(
+                    articleId = it.article.id,
+                    markAbove = false,
                 )
             }
         }

--- a/app/src/test/java/me/ash/reader/ui/page/adaptive/ArticleListReaderViewModelSelectionTest.kt
+++ b/app/src/test/java/me/ash/reader/ui/page/adaptive/ArticleListReaderViewModelSelectionTest.kt
@@ -1,0 +1,97 @@
+package me.ash.reader.ui.page.adaptive
+
+import java.util.Date
+import me.ash.reader.domain.model.article.Article
+import me.ash.reader.domain.model.article.ArticleFlowItem
+import me.ash.reader.domain.model.article.ArticleWithFeed
+import me.ash.reader.domain.model.feed.Feed
+import org.junit.Assert.assertEquals
+import org.junit.Test
+
+class ArticleListReaderViewModelSelectionTest {
+
+    @Test
+    fun `selectArticlesToMark marks articles above target when timestamps are tied`() {
+        val tiedDate = Date(1_780_292_811_000L)
+        val first = unreadArticle(id = "first", date = tiedDate)
+        val second = unreadArticle(id = "second", date = tiedDate)
+        val target = unreadArticle(id = "target", date = tiedDate)
+        val below = unreadArticle(id = "below", date = tiedDate)
+
+        val selected = selectArticlesToMark(
+            items = articleItems(first, second, target, below),
+            targetArticleId = "target",
+            markAbove = true,
+        )
+
+        assertEquals(listOf("first", "second"), selected.map { it.article.id })
+    }
+
+    @Test
+    fun `selectArticlesToMark marks articles below target when timestamps are tied`() {
+        val tiedDate = Date(1_780_292_811_000L)
+        val above = unreadArticle(id = "above", date = tiedDate)
+        val target = unreadArticle(id = "target", date = tiedDate)
+        val firstBelow = unreadArticle(id = "first-below", date = tiedDate)
+        val secondBelow = unreadArticle(id = "second-below", date = tiedDate)
+
+        val selected = selectArticlesToMark(
+            items = articleItems(above, target, firstBelow, secondBelow),
+            targetArticleId = "target",
+            markAbove = false,
+        )
+
+        assertEquals(listOf("first-below", "second-below"), selected.map { it.article.id })
+    }
+
+    @Test
+    fun `selectArticlesToMark excludes read items and duplicate ids`() {
+        val date = Date(1_780_292_811_000L)
+        val unread = unreadArticle(id = "unread", date = date)
+        val read = readArticle(id = "read", date = date)
+        val duplicate = unreadArticle(id = "unread", date = date)
+        val target = unreadArticle(id = "target", date = date)
+
+        val selected = selectArticlesToMark(
+            items = articleItems(unread, read, duplicate, target),
+            targetArticleId = "target",
+            markAbove = true,
+        )
+
+        assertEquals(listOf("unread"), selected.map { it.article.id })
+    }
+
+    private fun articleItems(vararg articles: ArticleWithFeed): List<ArticleFlowItem> =
+        articles.map { ArticleFlowItem.Article(it) }
+
+    private fun unreadArticle(id: String, date: Date): ArticleWithFeed =
+        ArticleWithFeed(
+            article =
+                Article(
+                    id = id,
+                    date = date,
+                    title = id,
+                    rawDescription = "<p>$id</p>",
+                    shortDescription = id,
+                    link = "https://example.com/$id",
+                    feedId = "feed",
+                    accountId = 1,
+                    isUnread = true,
+                ),
+            feed = sampleFeed(),
+        )
+
+    private fun readArticle(id: String, date: Date): ArticleWithFeed =
+        unreadArticle(id = id, date = date).run {
+            copy(article = article.copy(isUnread = false))
+        }
+
+    private fun sampleFeed(): Feed =
+        Feed(
+            id = "feed",
+            name = "Feed",
+            url = "https://example.com/feed",
+            groupId = "group",
+            accountId = 1,
+        )
+}


### PR DESCRIPTION
## Summary
Mark above/below as read now uses the rendered list order instead of comparing timestamps, so tied items no longer get skipped.

## Test
- ./gradlew :app:testGithubDebugUnitTest --tests me.ash.reader.ui.page.adaptive.ArticleListReaderViewModelSelectionTest
- ./gradlew :app:testGithubDebugUnitTest --tests 'me.ash.reader.ui.page.adaptive.*'

Closes #84