### PR TITLE
[codex] auto-dismiss mark-as-read snackbar

### DIFF
--- a/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
@@ -44,6 +44,7 @@ import androidx.compose.material3.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.SnackbarDuration
 import androidx.compose.material3.SnackbarResult
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBarDefaults
@@ -214,6 +215,7 @@ fun FlowPage(
                                 message = markedAsReadMessage,
                                 actionLabel = undoActionLabel,
                                 withDismissAction = true,
+                                duration = SnackbarDuration.Long,
                             )
                         if (result == SnackbarResult.ActionPerformed) {
                             performMarkedReadUndo(
@@ -244,6 +246,7 @@ fun FlowPage(
                                 message = markedAsReadMessage,
                                 actionLabel = undoActionLabel,
                                 withDismissAction = true,
+                                duration = SnackbarDuration.Long,
                             )
                         if (result == SnackbarResult.ActionPerformed) {
                             viewModel.undoReadStatus(articleIds)


### PR DESCRIPTION
## What changed
- Set the mark-as-read snackbar duration to `SnackbarDuration.Long` so it auto-dismisses after about 10 seconds.
- Kept the existing Undo action and dismiss affordance intact.

## Why
- The snackbar was previously using the Material3 default duration for action snackbars, which is indefinite.
- That caused the snackbar to remain visible until manual dismissal.

## Validation
- Installed the app on the Android emulator.
- Launched the app and verified the updated build runs on the emulator.

Fixes #92