### PR TITLE
fix(reader): allow mixed content compatibility mode

### DIFF
--- a/app/src/main/java/me/ash/reader/ui/component/webview/WebViewLayout.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/WebViewLayout.kt
@@ -52,6 +52,7 @@ object WebViewLayout {
                     }
                 domStorageEnabled = true
                 javaScriptEnabled = true
+                mixedContentMode = android.webkit.WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
                 mediaPlaybackRequiresUserGesture = false
                 addJavascriptInterface(
                     object : JavaScriptInterface {


### PR DESCRIPTION
Closes #91

Uses WebView mixed-content compatibility mode so the HTTP article image can load without custom HTML rewriting.