### PR TITLE
fix(reading): keep article content clear of collapsing header

### DIFF
--- a/app/src/main/java/me/ash/reader/ui/component/webview/RYWebView.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/RYWebView.kt
@@ -46,6 +46,13 @@ import me.ash.reader.ui.theme.palette.alwaysLight
 
 internal val LocalWebViewCreatedForTest = compositionLocalOf<((WebView) -> Unit)?> { null }
 
+data class WebViewScrollSnapshot(
+    val scrollY: Int,
+    val maxScrollY: Int,
+    val isAtTop: Boolean,
+    val isAtBottom: Boolean,
+)
+
 /**
  * Custom WebView that detects horizontal gestures and tells parent views not to intercept.
  * This allows horizontal scrolling in code blocks to work smoothly without triggering
@@ -57,6 +64,25 @@ class HorizontalScrollAwareWebView(context: Context) : WebView(context) {
     private var isHorizontalGesture: Boolean? = null
     private val touchSlop = ViewConfiguration.get(context).scaledTouchSlop.toFloat()
     var loadedContentKey: WebViewContentKey? = null
+    var onScrollSnapshotChanged: ((WebViewScrollSnapshot) -> Unit)? = null
+    var handledScrollToTopRequest: Int = 0
+
+    fun emitScrollSnapshot() {
+        val maxScrollY = (computeVerticalScrollRange() - computeVerticalScrollExtent()).coerceAtLeast(0)
+        onScrollSnapshotChanged?.invoke(
+            WebViewScrollSnapshot(
+                scrollY = scrollY,
+                maxScrollY = maxScrollY,
+                isAtTop = !canScrollVertically(-1),
+                isAtBottom = !canScrollVertically(1),
+            )
+        )
+    }
+
+    override fun onScrollChanged(l: Int, t: Int, oldl: Int, oldt: Int) {
+        super.onScrollChanged(l, t, oldl, oldt)
+        emitScrollSnapshot()
+    }
 
     @SuppressLint("ClickableViewAccessibility")
     override fun dispatchTouchEvent(event: MotionEvent): Boolean {
@@ -95,10 +121,12 @@ fun RYWebView(
     content: String,
     baseUrl: String? = null,
     refererDomain: String? = null,
+    scrollToTopRequest: Int = 0,
     onImageClick: ((imgUrl: String, altText: String) -> Unit)? = null,
     onLinkLongPress: ((url: String, text: String) -> Unit)? = null,
     onShowCustomView: ((View, WebChromeClient.CustomViewCallback) -> Unit)? = null,
     onHideCustomView: (() -> Unit)? = null,
+    onScrollSnapshotChange: ((WebViewScrollSnapshot) -> Unit)? = null,
 ) {
     val context = LocalContext.current
     val openLink = LocalOpenLink.current
@@ -130,6 +158,7 @@ fun RYWebView(
 
     val currentOpenLink by rememberUpdatedState(openLink)
     val currentOpenLinkSpecificBrowser by rememberUpdatedState(openLinkSpecificBrowser)
+    val onScrollSnapshotChangeState by rememberUpdatedState(onScrollSnapshotChange)
     val dynamicWebViewClient = remember(context, refererDomain) {
         WebViewClient(
             context = context,
@@ -185,6 +214,7 @@ fun RYWebView(
         modifier = modifier,
         factory = { webView },
         update = { wv ->
+            wv.onScrollSnapshotChanged = { snapshot -> onScrollSnapshotChangeState?.invoke(snapshot) }
             if (wv.webViewClient !== dynamicWebViewClient) {
                 wv.webViewClient = dynamicWebViewClient
             }
@@ -238,6 +268,14 @@ fun RYWebView(
                     "UTF-8",
                     null,
                 )
+                wv.post { wv.emitScrollSnapshot() }
+            }
+            if (scrollToTopRequest != 0 && scrollToTopRequest != wv.handledScrollToTopRequest) {
+                wv.handledScrollToTopRequest = scrollToTopRequest
+                wv.post {
+                    wv.scrollTo(0, 0)
+                    wv.emitScrollSnapshot()
+                }
             }
         },
     )

--- a/app/src/main/java/me/ash/reader/ui/page/home/reading/Content.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/reading/Content.kt
@@ -19,14 +19,15 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.unit.dp
 import java.util.Date
 import me.ash.reader.ui.component.reader.LocalTextContentWidth
 import me.ash.reader.ui.component.scrollbar.drawVerticalScrollIndicator
 import me.ash.reader.ui.component.webview.RYWebView
+import me.ash.reader.ui.component.webview.WebViewScrollSnapshot
 import me.ash.reader.ui.ext.extractDomain
-import me.ash.reader.ui.ext.roundClick
 
 @OptIn(ExperimentalMaterial3ExpressiveApi::class)
 @Composable
@@ -41,10 +42,13 @@ fun Content(
     scrollState: ScrollState,
     isLoading: Boolean,
     contentPadding: PaddingValues = PaddingValues(),
+    scrollToTopRequest: Int = 0,
+    onHeadlineMeasured: ((Int) -> Unit)? = null,
     onImageClick: ((imgUrl: String, altText: String) -> Unit)? = null,
     onLinkLongPress: ((url: String, text: String) -> Unit)? = null,
     onShowCustomView: ((View, WebChromeClient.CustomViewCallback) -> Unit)? = null,
     onHideCustomView: (() -> Unit)? = null,
+    onScrollSnapshotChange: ((WebViewScrollSnapshot) -> Unit)? = null,
 ) {
     val textContentWidth = LocalTextContentWidth.current
     val maxWidthModifier = Modifier.widthIn(max = textContentWidth)
@@ -55,7 +59,13 @@ fun Content(
 
     val headline =
         @Composable {
-            Column(modifier = Modifier.then(maxWidthModifier).padding(horizontal = 12.dp)) {
+            Column(
+                modifier =
+                    Modifier
+                        .then(maxWidthModifier)
+                        .padding(horizontal = 12.dp)
+                        .onSizeChanged { onHeadlineMeasured?.invoke(it.height) }
+            ) {
                 DisableSelection {
                     Metadata(
                         feedName = feedName,
@@ -90,10 +100,12 @@ fun Content(
                     content = content,
                     baseUrl = link,
                     refererDomain = link.extractDomain(),
+                    scrollToTopRequest = scrollToTopRequest,
                     onImageClick = onImageClick,
                     onLinkLongPress = onLinkLongPress,
                     onShowCustomView = onShowCustomView,
                     onHideCustomView = onHideCustomView,
+                    onScrollSnapshotChange = onScrollSnapshotChange,
                 )
                 Spacer(modifier = Modifier.height(128.dp))
                 Spacer(modifier = Modifier.height(contentPadding.calculateBottomPadding()))

--- a/app/src/main/java/me/ash/reader/ui/page/home/reading/ReadingPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/reading/ReadingPage.kt
@@ -294,7 +294,7 @@ fun ReadingPage(
                                 }
 
                                 // Track scroll position for toolbar visibility
-                                LaunchedEffect(scrollState, webViewScrollSnapshot) {
+                                LaunchedEffect(scrollState, collapsedHeaderOffsetPx) {
                                     var lastPosition =
                                         scrollState.value.coerceAtMost(collapsedHeaderOffsetPx) +
                                             webViewScrollSnapshot.scrollY

--- a/app/src/main/java/me/ash/reader/ui/page/home/reading/ReadingPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/reading/ReadingPage.kt
@@ -70,6 +70,13 @@ import me.ash.reader.ui.page.home.reading.tts.TtsButton
 private const val UPWARD = 1
 private const val DOWNWARD = -1
 
+private data class ToolbarScrollSample(
+    val position: Int,
+    val maxScroll: Int,
+    val webViewSnapshot: WebViewScrollSnapshot,
+    val scrollable: Boolean,
+)
+
 @OptIn(ExperimentalFoundationApi::class, ExperimentalMaterialApi::class)
 @Composable
 fun ReadingPage(
@@ -288,27 +295,37 @@ fun ReadingPage(
 
                                 // Track scroll position for toolbar visibility
                                 LaunchedEffect(scrollState, webViewScrollSnapshot) {
-                                    var lastPosition = scrollState.value
+                                    var lastPosition =
+                                        scrollState.value.coerceAtMost(collapsedHeaderOffsetPx) +
+                                            webViewScrollSnapshot.scrollY
                                     snapshotFlow {
-                                        Triple(
-                                            scrollState.value,
-                                            scrollState.maxValue,
-                                            scrollState.maxValue > 0 || webViewScrollSnapshot.maxScrollY > 0
+                                        ToolbarScrollSample(
+                                            position = scrollState.value,
+                                            maxScroll = scrollState.maxValue,
+                                            webViewSnapshot = webViewScrollSnapshot,
+                                            scrollable =
+                                                scrollState.maxValue > 0 ||
+                                                    webViewScrollSnapshot.maxScrollY > 0
                                         )
-                                    }.distinctUntilChanged().collect { (position, maxScroll, scrollable) ->
-                                        isScrollable = scrollable
+                                    }.distinctUntilChanged().collect { sample ->
+                                        isScrollable = sample.scrollable
                                         isAtTop =
-                                            ReaderToolbarState.isAtTop(position) &&
-                                                webViewScrollSnapshot.isAtTop
+                                            ReaderToolbarState.isAtTop(sample.position) &&
+                                                sample.webViewSnapshot.isAtTop
                                         isAtBottom =
-                                            ReaderToolbarState.isAtBottom(position, maxScroll) &&
-                                                webViewScrollSnapshot.isAtBottom
+                                            ReaderToolbarState.isAtBottom(
+                                                sample.position,
+                                                sample.maxScroll,
+                                            ) && sample.webViewSnapshot.isAtBottom
                                         // Track scroll direction for toolbar visibility
-                                        val delta = position - lastPosition
+                                        val combinedPosition =
+                                            sample.position.coerceAtMost(collapsedHeaderOffsetPx) +
+                                                sample.webViewSnapshot.scrollY
+                                        val delta = combinedPosition - lastPosition
                                         if (abs(delta) > 2) {
                                             isReaderScrollingDown = delta > 0
                                         }
-                                        lastPosition = position
+                                        lastPosition = combinedPosition
                                     }
                                 }
 

--- a/app/src/main/java/me/ash/reader/ui/page/home/reading/ReadingPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/reading/ReadingPage.kt
@@ -40,8 +40,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.TextUnit
+import androidx.compose.ui.unit.dp
 import androidx.compose.ui.unit.isSpecified
 import androidx.compose.ui.unit.sp
 import androidx.compose.ui.viewinterop.AndroidView
@@ -53,6 +55,7 @@ import kotlinx.coroutines.launch
 import me.ash.reader.R
 import me.ash.reader.ui.component.webview.LinkActionDialog
 import me.ash.reader.ui.component.webview.LinkActionData
+import me.ash.reader.ui.component.webview.WebViewScrollSnapshot
 import me.ash.reader.infrastructure.android.TextToSpeechManager
 import me.ash.reader.infrastructure.preference.LocalPullToSwitchArticle
 import me.ash.reader.infrastructure.preference.LocalReadingAutoHideToolbar
@@ -79,6 +82,7 @@ fun ReadingPage(
 ) {
     val context = LocalContext.current
     val hapticFeedback = LocalHapticFeedback.current
+    val density = LocalDensity.current
     val isPullToSwitchArticleEnabled = LocalPullToSwitchArticle.current.value
     val readingUiState = viewModel.readingUiState.collectAsStateValue()
     val readerState = viewModel.readerStateStateFlow.collectAsStateValue()
@@ -96,6 +100,18 @@ fun ReadingPage(
 
     var isReaderScrollingDown by remember { mutableStateOf(false) }
     var showFullScreenImageViewer by remember { mutableStateOf(false) }
+    var webViewScrollSnapshot by remember(contentStateKey, readerState.articleId) {
+        mutableStateOf(
+            WebViewScrollSnapshot(
+                scrollY = 0,
+                maxScrollY = 0,
+                isAtTop = true,
+                isAtBottom = true,
+            )
+        )
+    }
+    var headlineHeightPx by remember(contentStateKey, readerState.articleId) { mutableStateOf(0) }
+    var scrollToTopRequest by remember(contentStateKey, readerState.articleId) { mutableStateOf(0) }
     
     // Track scroll position for toolbar visibility
     var isScrollable by remember { mutableStateOf(false) }
@@ -136,6 +152,7 @@ fun ReadingPage(
     //    }
 
     var bringToTop by remember { mutableStateOf(false) }
+    val collapsedHeaderOffsetPx = with(density) { 64.dp.toPx() }.toInt() + headlineHeightPx
 
     LinkActionDialog(
         visible = showLinkActionDialog,
@@ -242,6 +259,7 @@ fun ReadingPage(
 
                                 LaunchedEffect(bringToTop) {
                                     if (bringToTop) {
+                                        scrollToTopRequest += 1
                                         scope
                                             .launch {
                                                 scrollState.animateScrollTo(0)
@@ -252,23 +270,39 @@ fun ReadingPage(
 
                                 showTopDivider =
                                     snapshotFlow {
-                                            scrollState.value >= 120
+                                            scrollState.value >= 120 || !webViewScrollSnapshot.isAtTop
                                         }
                                         .collectAsStateValue(initial = false)
 
+                                LaunchedEffect(scrollState, webViewScrollSnapshot, collapsedHeaderOffsetPx) {
+                                    snapshotFlow { scrollState.value }
+                                        .collect { position ->
+                                            if (!webViewScrollSnapshot.isAtTop &&
+                                                collapsedHeaderOffsetPx > 0 &&
+                                                position < collapsedHeaderOffsetPx
+                                            ) {
+                                                scrollState.scrollTo(collapsedHeaderOffsetPx)
+                                            }
+                                        }
+                                }
+
                                 // Track scroll position for toolbar visibility
-                                LaunchedEffect(scrollState) {
+                                LaunchedEffect(scrollState, webViewScrollSnapshot) {
                                     var lastPosition = scrollState.value
                                     snapshotFlow {
                                         Triple(
                                             scrollState.value,
                                             scrollState.maxValue,
-                                            scrollState.maxValue > 0
+                                            scrollState.maxValue > 0 || webViewScrollSnapshot.maxScrollY > 0
                                         )
                                     }.distinctUntilChanged().collect { (position, maxScroll, scrollable) ->
                                         isScrollable = scrollable
-                                        isAtTop = ReaderToolbarState.isAtTop(position)
-                                        isAtBottom = ReaderToolbarState.isAtBottom(position, maxScroll)
+                                        isAtTop =
+                                            ReaderToolbarState.isAtTop(position) &&
+                                                webViewScrollSnapshot.isAtTop
+                                        isAtBottom =
+                                            ReaderToolbarState.isAtBottom(position, maxScroll) &&
+                                                webViewScrollSnapshot.isAtBottom
                                         // Track scroll direction for toolbar visibility
                                         val delta = position - lastPosition
                                         if (abs(delta) > 2) {
@@ -313,9 +347,14 @@ fun ReadingPage(
                                             publishedDate = publishedDate,
                                             isLoading = content is ReaderState.Loading,
                                             scrollState = scrollState,
+                                            scrollToTopRequest = scrollToTopRequest,
+                                            onHeadlineMeasured = { headlineHeightPx = it },
                                             onImageClick = { imgUrl, altText ->
                                                 currentImageData = ImageData(imgUrl, altText)
                                                 showFullScreenImageViewer = true
+                                            },
+                                            onScrollSnapshotChange = {
+                                                webViewScrollSnapshot = it
                                             },
                                             onLinkLongPress = { url, text ->
                                                 linkActionData = LinkActionData(


### PR DESCRIPTION
## Summary
- track WebView inner scroll position in the reading page
- clamp the outer reading scroll while the WebView is not back at its own top
- preserve pull-to-switch and toolbar behavior without locking scroll direction

Closes #95