### PR TITLE
perf(webview): prewarm first article render

### DIFF
--- a/app/src/androidTest/java/me/ash/reader/ui/component/webview/RYWebViewMediaLifecycleTest.kt
+++ b/app/src/androidTest/java/me/ash/reader/ui/component/webview/RYWebViewMediaLifecycleTest.kt
@@ -10,7 +10,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.test.junit4.createAndroidComposeRule
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import org.junit.Assert.assertNotNull
-import org.junit.Assert.assertThrows
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNull
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -22,7 +23,7 @@ class RYWebViewMediaLifecycleTest {
     val composeRule = createAndroidComposeRule<ComponentActivity>()
 
     @Test
-    fun articleWebViewIsDestroyedWhenRemovedFromComposition() {
+    fun articleWebViewIsRecycledWhenRemovedFromComposition() {
         var showArticle by mutableStateOf(true)
         var articleWebView: WebView? = null
 
@@ -49,12 +50,11 @@ class RYWebViewMediaLifecycleTest {
 
         assertNotNull(articleWebView)
         composeRule.runOnUiThread {
-            assertThrows(
-                "Expected a removed article WebView to be destroyed so in-page audio/video cannot keep running.",
-                IllegalStateException::class.java,
-            ) {
-                articleWebView!!.evaluateJavascript("document.querySelector('audio').paused", null)
-            }
+            val webView = articleWebView as HorizontalScrollAwareWebView
+            assertNull(webView.parent)
+            assertNull(webView.loadedContentKey)
+            assertNull(webView.webChromeClient)
+            assertEquals(0, webView.scrollY)
         }
     }
 

--- a/app/src/main/java/me/ash/reader/ui/component/webview/RYWebView.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/RYWebView.kt
@@ -2,6 +2,7 @@ package me.ash.reader.ui.component.webview
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.os.SystemClock
 import timber.log.Timber
 import android.view.MotionEvent
 import android.view.View
@@ -14,6 +15,7 @@ import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.compositionLocalOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.produceState
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.ui.Modifier
@@ -22,6 +24,8 @@ import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.withContext
 import kotlin.math.abs
 import me.ash.reader.infrastructure.preference.LocalOpenLink
 import me.ash.reader.infrastructure.preference.LocalOpenLinkSpecificBrowser
@@ -65,6 +69,8 @@ class HorizontalScrollAwareWebView(context: Context) : WebView(context) {
     private val touchSlop = ViewConfiguration.get(context).scaledTouchSlop.toFloat()
     var loadedContentKey: WebViewContentKey? = null
     var onScrollSnapshotChanged: ((WebViewScrollSnapshot) -> Unit)? = null
+    var onImageClick: ((imgUrl: String, altText: String) -> Unit)? = null
+    var onLinkLongPress: ((url: String, text: String) -> Unit)? = null
     var handledScrollToTopRequest: Int = 0
 
     fun emitScrollSnapshot() {
@@ -185,7 +191,7 @@ fun RYWebView(
     val webView by
         remember {
             mutableStateOf(
-                WebViewLayout.get(
+                WebViewLayout.acquire(
                     context = context,
                     readingFontsPreference = readingFonts,
                     webViewClient = dynamicWebViewClient,
@@ -203,10 +209,48 @@ fun RYWebView(
             "/android_res/font/google_sans_flex.ttf"
         } else null
     val htmlBaseUrl = baseUrl ?: "about:blank"
+    val articleHtml by
+        produceState<String?>(initialValue = null, content, htmlBaseUrl, fontSize, fontPath, lineHeight, letterSpacing, textMargin, textColor, textBold, textAlign, boldTextColor, subheadBold, subheadUpperCase, imgMargin, imgBorderRadius, linkTextColor, codeTextColor, codeBgColor, selectionTextColor, selectionBgColor, boldCharacters.value) {
+            val buildStartedAtMs = SystemClock.elapsedRealtime()
+            value =
+                withContext(Dispatchers.Default) {
+                    WebViewHtml.HTML.format(
+                        WebViewStyle.get(
+                            fontSize = fontSize,
+                            fontPath = fontPath,
+                            lineHeight = lineHeight,
+                            letterSpacing = letterSpacing,
+                            textMargin = textMargin,
+                            textColor = textColor,
+                            textBold = textBold,
+                            textAlign = textAlign,
+                            boldTextColor = boldTextColor,
+                            subheadBold = subheadBold,
+                            subheadUpperCase = subheadUpperCase,
+                            imgMargin = imgMargin,
+                            imgBorderRadius = imgBorderRadius,
+                            linkTextColor = linkTextColor,
+                            codeTextColor = codeTextColor,
+                            codeBgColor = codeBgColor,
+                            tableMargin = textMargin,
+                            selectionTextColor = selectionTextColor,
+                            selectionBgColor = selectionBgColor,
+                        ),
+                        htmlBaseUrl,
+                        content,
+                        WebViewScript.get(boldCharacters.value),
+                    )
+                }
+            Timber.tag("RYWebViewPerf").d(
+                "html build in %d ms (%d chars)",
+                SystemClock.elapsedRealtime() - buildStartedAtMs,
+                value?.length ?: 0,
+            )
+        }
 
     DisposableEffect(Unit) {
         onDispose {
-            webView.releaseArticleMedia(webChromeClient)
+            WebViewLayout.release(webView)
         }
     }
 
@@ -229,37 +273,9 @@ fun RYWebView(
                     ReadingFontsPreference.Serif -> "serif"
                     else -> "sans-serif"
                 }
-            val html =
-                WebViewHtml.HTML.format(
-                    WebViewStyle.get(
-                        fontSize = fontSize,
-                        fontPath = fontPath,
-                        lineHeight = lineHeight,
-                        letterSpacing = letterSpacing,
-                        textMargin = textMargin,
-                        textColor = textColor,
-                        textBold = textBold,
-                        textAlign = textAlign,
-                        boldTextColor = boldTextColor,
-                        subheadBold = subheadBold,
-                        subheadUpperCase = subheadUpperCase,
-                        imgMargin = imgMargin,
-                        imgBorderRadius = imgBorderRadius,
-                        linkTextColor = linkTextColor,
-                        codeTextColor = codeTextColor,
-                        codeBgColor = codeBgColor,
-                        tableMargin = textMargin,
-                        selectionTextColor = selectionTextColor,
-                        selectionBgColor = selectionBgColor,
-                    ),
-                    htmlBaseUrl,
-                    content,
-                    WebViewScript.get(boldCharacters.value),
-                )
+            val html = articleHtml ?: return@AndroidView
             val contentKey = WebViewContentKey(htmlBaseUrl, html, fontSize)
             if (wv.loadedContentKey != contentKey) {
-                Timber.tag("RLog").i("readingFont: ${context.filesDir.absolutePath}")
-                Timber.tag("RLog").i("CustomWebView: ${content}")
                 wv.loadedContentKey = contentKey
                 wv.loadDataWithBaseURL(
                     htmlBaseUrl,
@@ -279,16 +295,4 @@ fun RYWebView(
             }
         },
     )
-}
-
-private fun WebView.releaseArticleMedia(webChromeClient: RYWebChromeClient?) {
-    webChromeClient?.releaseCustomView()
-    (parent as? android.view.ViewGroup)?.removeView(this)
-    runCatching { stopLoading() }
-    runCatching { loadUrl("about:blank") }
-    runCatching { onPause() }
-    runCatching { removeAllViews() }
-    runCatching { this.webChromeClient = null }
-    runCatching { this.webViewClient = android.webkit.WebViewClient() }
-    runCatching { destroy() }
 }

--- a/app/src/main/java/me/ash/reader/ui/component/webview/RYWebView.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/RYWebView.kt
@@ -191,7 +191,7 @@ fun RYWebView(
     val webView by
         remember {
             mutableStateOf(
-                WebViewLayout.acquire(
+                WebViewLayout.obtain(
                     context = context,
                     readingFontsPreference = readingFonts,
                     webViewClient = dynamicWebViewClient,
@@ -212,6 +212,7 @@ fun RYWebView(
     val articleHtml by
         produceState<String?>(initialValue = null, content, htmlBaseUrl, fontSize, fontPath, lineHeight, letterSpacing, textMargin, textColor, textBold, textAlign, boldTextColor, subheadBold, subheadUpperCase, imgMargin, imgBorderRadius, linkTextColor, codeTextColor, codeBgColor, selectionTextColor, selectionBgColor, boldCharacters.value) {
             val buildStartedAtMs = SystemClock.elapsedRealtime()
+            value = null
             value =
                 withContext(Dispatchers.Default) {
                     WebViewHtml.HTML.format(
@@ -250,7 +251,7 @@ fun RYWebView(
 
     DisposableEffect(Unit) {
         onDispose {
-            WebViewLayout.release(webView)
+            WebViewLayout.recycle(webView)
         }
     }
 

--- a/app/src/main/java/me/ash/reader/ui/component/webview/WebViewClient.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/WebViewClient.kt
@@ -41,12 +41,22 @@ class WebViewClient(
             } catch (e: Exception) {
                 Timber.tag("RLog").e(e, "WebView shouldInterceptRequest")
             }
-        } else if (url != null && url.isUrl()) {
+        } else if (
+            url != null &&
+            url.isUrl() &&
+            !refererDomain.isNullOrBlank() &&
+            request?.isForMainFrame == false &&
+            url.isLikelyMediaResource()
+        ) {
             try {
                 var connection = URI.create(url).toURL().openConnection() as HttpURLConnection
+                connection.connectTimeout = RESOURCE_TIMEOUT_MS
+                connection.readTimeout = RESOURCE_TIMEOUT_MS
                 if (connection.responseCode == 403) {
                     connection.disconnect()
                     connection = URI.create(url).toURL().openConnection() as HttpURLConnection
+                    connection.connectTimeout = RESOURCE_TIMEOUT_MS
+                    connection.readTimeout = RESOURCE_TIMEOUT_MS
                     connection.setRequestProperty("Referer", refererDomain)
                     val inputStream = DataInputStream(connection.inputStream)
                     return WebResourceResponse(connection.contentType, "UTF-8", inputStream)
@@ -97,6 +107,8 @@ class WebViewClient(
     }
 
     companion object {
+        private const val RESOURCE_TIMEOUT_MS = 3_000
+
         private const val OnImgClickScript = """
             javascript:(function() {
                 var imgs = document.getElementsByTagName("img");
@@ -177,4 +189,20 @@ class WebViewClient(
             })()
             """
     }
+}
+
+private fun String.isLikelyMediaResource(): Boolean {
+    val path = substringBefore('?').lowercase()
+    return path.endsWith(".jpg") ||
+        path.endsWith(".jpeg") ||
+        path.endsWith(".png") ||
+        path.endsWith(".gif") ||
+        path.endsWith(".webp") ||
+        path.endsWith(".bmp") ||
+        path.endsWith(".svg") ||
+        path.endsWith(".avif") ||
+        path.endsWith(".mp4") ||
+        path.endsWith(".webm") ||
+        path.endsWith(".m3u8") ||
+        path.endsWith(".ogg")
 }

--- a/app/src/main/java/me/ash/reader/ui/component/webview/WebViewClient.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/WebViewClient.kt
@@ -45,8 +45,7 @@ class WebViewClient(
             url != null &&
             url.isUrl() &&
             !refererDomain.isNullOrBlank() &&
-            request?.isForMainFrame == false &&
-            url.isLikelyMediaResource()
+            request?.isForMainFrame == false
         ) {
             try {
                 var connection = URI.create(url).toURL().openConnection() as HttpURLConnection
@@ -189,20 +188,4 @@ class WebViewClient(
             })()
             """
     }
-}
-
-private fun String.isLikelyMediaResource(): Boolean {
-    val path = substringBefore('#').substringBefore('?').lowercase()
-    return path.endsWith(".jpg") ||
-        path.endsWith(".jpeg") ||
-        path.endsWith(".png") ||
-        path.endsWith(".gif") ||
-        path.endsWith(".webp") ||
-        path.endsWith(".bmp") ||
-        path.endsWith(".svg") ||
-        path.endsWith(".avif") ||
-        path.endsWith(".mp4") ||
-        path.endsWith(".webm") ||
-        path.endsWith(".m3u8") ||
-        path.endsWith(".ogg")
 }

--- a/app/src/main/java/me/ash/reader/ui/component/webview/WebViewClient.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/WebViewClient.kt
@@ -192,7 +192,7 @@ class WebViewClient(
 }
 
 private fun String.isLikelyMediaResource(): Boolean {
-    val path = substringBefore('?').lowercase()
+    val path = substringBefore('#').substringBefore('?').lowercase()
     return path.endsWith(".jpg") ||
         path.endsWith(".jpeg") ||
         path.endsWith(".png") ||

--- a/app/src/main/java/me/ash/reader/ui/component/webview/WebViewLayout.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/WebViewLayout.kt
@@ -3,12 +3,74 @@ package me.ash.reader.ui.component.webview
 import android.annotation.SuppressLint
 import android.content.Context
 import android.graphics.Color
-import timber.log.Timber
 import android.webkit.JavascriptInterface
 import me.ash.reader.infrastructure.preference.ReadingFontsPreference
 
 @Suppress("DEPRECATION")
 object WebViewLayout {
+    private var pooledWebView: HorizontalScrollAwareWebView? = null
+
+    fun prewarm(
+        context: Context,
+        readingFontsPreference: ReadingFontsPreference,
+    ) {
+        if (pooledWebView != null) return
+        pooledWebView =
+            createWebView(
+                context = context,
+                readingFontsPreference = readingFontsPreference,
+                webViewClient = android.webkit.WebViewClient(),
+                webChromeClient = null,
+                onImageClick = null,
+                onLinkLongPress = null,
+            )
+    }
+
+    fun acquire(
+        context: Context,
+        readingFontsPreference: ReadingFontsPreference,
+        webViewClient: WebViewClient,
+        webChromeClient: RYWebChromeClient? = null,
+        onImageClick: ((imgUrl: String, altText: String) -> Unit)? = null,
+        onLinkLongPress: ((url: String, text: String) -> Unit)? = null,
+    ): HorizontalScrollAwareWebView {
+        val webView =
+            pooledWebView?.also { pooledWebView = null }
+                ?: createWebView(
+                    context = context,
+                    readingFontsPreference = readingFontsPreference,
+                    webViewClient = webViewClient,
+                    webChromeClient = webChromeClient,
+                    onImageClick = onImageClick,
+                    onLinkLongPress = onLinkLongPress,
+                )
+        configureWebView(
+            webView = webView,
+            readingFontsPreference = readingFontsPreference,
+            webViewClient = webViewClient,
+            webChromeClient = webChromeClient,
+            onImageClick = onImageClick,
+            onLinkLongPress = onLinkLongPress,
+        )
+        return webView
+    }
+
+    fun release(webView: HorizontalScrollAwareWebView) {
+        (webView.parent as? android.view.ViewGroup)?.removeView(webView)
+        webView.loadedContentKey = null
+        webView.onScrollSnapshotChanged = null
+        webView.onImageClick = null
+        webView.onLinkLongPress = null
+        webView.handledScrollToTopRequest = 0
+        runCatching { webView.stopLoading() }
+        runCatching { webView.loadUrl("about:blank") }
+        runCatching { webView.onPause() }
+        runCatching { webView.clearHistory() }
+        runCatching { webView.scrollTo(0, 0) }
+        runCatching { webView.webChromeClient = null }
+        runCatching { webView.webViewClient = android.webkit.WebViewClient() }
+        pooledWebView = webView
+    }
 
     @SuppressLint("SetJavaScriptEnabled")
     fun get(
@@ -18,64 +80,93 @@ object WebViewLayout {
         webChromeClient: RYWebChromeClient? = null,
         onImageClick: ((imgUrl: String, altText: String) -> Unit)? = null,
         onLinkLongPress: ((url: String, text: String) -> Unit)? = null,
-    ): HorizontalScrollAwareWebView {
-                Timber.tag("WebViewLayout").d("Creating WebView with webChromeClient=$webChromeClient")
-        return HorizontalScrollAwareWebView(context).apply {
-            this.webViewClient = webViewClient
-            webChromeClient?.let { 
-                        Timber.tag("WebViewLayout").d("Setting webChromeClient: $it")
-                this.webChromeClient = it 
-            } ?: Timber.tag("WebViewLayout").d("webChromeClient is null, not setting")
+    ): HorizontalScrollAwareWebView =
+        acquire(
+            context = context,
+            readingFontsPreference = readingFontsPreference,
+            webViewClient = webViewClient,
+            webChromeClient = webChromeClient,
+            onImageClick = onImageClick,
+            onLinkLongPress = onLinkLongPress,
+        )
+
+    @SuppressLint("SetJavaScriptEnabled")
+    private fun createWebView(
+        context: Context,
+        readingFontsPreference: ReadingFontsPreference,
+        webViewClient: android.webkit.WebViewClient,
+        webChromeClient: RYWebChromeClient?,
+        onImageClick: ((imgUrl: String, altText: String) -> Unit)?,
+        onLinkLongPress: ((url: String, text: String) -> Unit)?,
+    ): HorizontalScrollAwareWebView =
+        HorizontalScrollAwareWebView(context).apply {
             scrollBarSize = 0
             isHorizontalScrollBarEnabled = false
             isVerticalScrollBarEnabled = true
             setBackgroundColor(Color.TRANSPARENT)
-            with(this.settings) {
-                standardFontFamily =
-                    when (readingFontsPreference) {
-                        ReadingFontsPreference.Cursive -> "cursive"
-                        ReadingFontsPreference.Monospace -> "monospace"
-                        ReadingFontsPreference.SansSerif -> "sans-serif"
-                        ReadingFontsPreference.Serif -> "serif"
-                        ReadingFontsPreference.GoogleSans -> {
-                            allowFileAccess = true
-                            allowFileAccessFromFileURLs = true
-                            "sans-serif"
+            addJavascriptInterface(
+                object : JavaScriptInterface {
+                    @JavascriptInterface
+                    override fun onImgTagClick(imgUrl: String?, alt: String?) {
+                        if (imgUrl != null) {
+                            this@apply.onImageClick?.invoke(imgUrl, alt ?: "")
                         }
-                        ReadingFontsPreference.External -> {
-                            allowFileAccess = true
-                            allowFileAccessFromFileURLs = true
-                            "sans-serif"
-                        }
-
-                        else -> "sans-serif"
                     }
-                domStorageEnabled = true
-                javaScriptEnabled = true
-                mixedContentMode = android.webkit.WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
-                mediaPlaybackRequiresUserGesture = false
-                addJavascriptInterface(
-                    object : JavaScriptInterface {
-                        @JavascriptInterface
-                        override fun onImgTagClick(imgUrl: String?, alt: String?) {
-                            if (onImageClick != null && imgUrl != null) {
-                                onImageClick.invoke(imgUrl, alt ?: "")
-                            }
-                        }
 
-                        @JavascriptInterface
-                        override fun onLinkLongPress(url: String?, text: String?) {
-                            if (onLinkLongPress != null && url != null) {
-                                onLinkLongPress.invoke(url, text ?: "")
-                            }
+                    @JavascriptInterface
+                    override fun onLinkLongPress(url: String?, text: String?) {
+                        if (url != null) {
+                            this@apply.onLinkLongPress?.invoke(url, text ?: "")
                         }
-                    },
-                    JavaScriptInterface.NAME,
-                )
-                setSupportZoom(false)
-                if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
-                    isAlgorithmicDarkeningAllowed = true
+                    }
+                },
+                JavaScriptInterface.NAME,
+            )
+            configureWebView(
+                webView = this,
+                readingFontsPreference = readingFontsPreference,
+                webViewClient = webViewClient,
+                webChromeClient = webChromeClient,
+                onImageClick = onImageClick,
+                onLinkLongPress = onLinkLongPress,
+            )
+        }
+
+    private fun configureWebView(
+        webView: HorizontalScrollAwareWebView,
+        readingFontsPreference: ReadingFontsPreference,
+        webViewClient: android.webkit.WebViewClient,
+        webChromeClient: RYWebChromeClient?,
+        onImageClick: ((imgUrl: String, altText: String) -> Unit)?,
+        onLinkLongPress: ((url: String, text: String) -> Unit)?,
+    ) {
+        webView.onImageClick = onImageClick
+        webView.onLinkLongPress = onLinkLongPress
+        webView.webViewClient = webViewClient
+        webView.webChromeClient = webChromeClient
+        webView.onResume()
+        with(webView.settings) {
+            standardFontFamily =
+                when (readingFontsPreference) {
+                    ReadingFontsPreference.Cursive -> "cursive"
+                    ReadingFontsPreference.Monospace -> "monospace"
+                    ReadingFontsPreference.SansSerif -> "sans-serif"
+                    ReadingFontsPreference.Serif -> "serif"
+                    ReadingFontsPreference.GoogleSans,
+                    ReadingFontsPreference.External,
+                    ReadingFontsPreference.System -> "sans-serif"
                 }
+            allowFileAccess =
+                readingFontsPreference == ReadingFontsPreference.GoogleSans ||
+                    readingFontsPreference == ReadingFontsPreference.External
+            allowFileAccessFromFileURLs = allowFileAccess
+            domStorageEnabled = true
+            javaScriptEnabled = true
+            mixedContentMode = android.webkit.WebSettings.MIXED_CONTENT_COMPATIBILITY_MODE
+            mediaPlaybackRequiresUserGesture = false
+            setSupportZoom(false)
+            if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.TIRAMISU) {
+                isAlgorithmicDarkeningAllowed = true
             }
         }
     }

--- a/app/src/main/java/me/ash/reader/ui/component/webview/WebViewLayout.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/WebViewLayout.kt
@@ -9,6 +9,17 @@ import me.ash.reader.infrastructure.preference.ReadingFontsPreference
 @Suppress("DEPRECATION")
 object WebViewLayout {
     private var pooledWebView: HorizontalScrollAwareWebView? = null
+    private const val PREWARM_BASE_URL = "about:blank"
+    private const val PREWARM_HTML =
+        """
+        <!DOCTYPE html>
+        <html>
+        <head>
+            <meta name="viewport" content="width=device-width, initial-scale=1" />
+        </head>
+        <body></body>
+        </html>
+        """
 
     fun prewarm(
         context: Context,
@@ -23,7 +34,15 @@ object WebViewLayout {
                 webChromeClient = null,
                 onImageClick = null,
                 onLinkLongPress = null,
-            )
+            ).also { webView ->
+                webView.loadDataWithBaseURL(
+                    PREWARM_BASE_URL,
+                    PREWARM_HTML,
+                    "text/html",
+                    "UTF-8",
+                    null,
+                )
+            }
     }
 
     fun acquire(

--- a/app/src/main/java/me/ash/reader/ui/component/webview/WebViewLayout.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/WebViewLayout.kt
@@ -2,13 +2,14 @@ package me.ash.reader.ui.component.webview
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.content.MutableContextWrapper
 import android.graphics.Color
 import android.webkit.JavascriptInterface
 import me.ash.reader.infrastructure.preference.ReadingFontsPreference
 
 @Suppress("DEPRECATION")
 object WebViewLayout {
-    private var pooledWebView: HorizontalScrollAwareWebView? = null
+    private var retainedWebView: HorizontalScrollAwareWebView? = null
     private const val PREWARM_BASE_URL = "about:blank"
     private const val PREWARM_HTML =
         """
@@ -25,27 +26,15 @@ object WebViewLayout {
         context: Context,
         readingFontsPreference: ReadingFontsPreference,
     ) {
-        if (pooledWebView != null) return
-        pooledWebView =
-            createWebView(
-                context = context,
+        if (retainedWebView != null) return
+        retainedWebView =
+            buildRetainedWebView(
+                context = context.applicationContext,
                 readingFontsPreference = readingFontsPreference,
-                webViewClient = android.webkit.WebViewClient(),
-                webChromeClient = null,
-                onImageClick = null,
-                onLinkLongPress = null,
-            ).also { webView ->
-                webView.loadDataWithBaseURL(
-                    PREWARM_BASE_URL,
-                    PREWARM_HTML,
-                    "text/html",
-                    "UTF-8",
-                    null,
-                )
-            }
+            )
     }
 
-    fun acquire(
+    fun obtain(
         context: Context,
         readingFontsPreference: ReadingFontsPreference,
         webViewClient: WebViewClient,
@@ -54,9 +43,11 @@ object WebViewLayout {
         onLinkLongPress: ((url: String, text: String) -> Unit)? = null,
     ): HorizontalScrollAwareWebView {
         val webView =
-            pooledWebView?.also { pooledWebView = null }
-                ?: createWebView(
-                    context = context,
+            retainedWebView?.also {
+                retainedWebView = null
+                (it.context as? MutableContextWrapper)?.baseContext = context
+            } ?: createWebView(
+                    context = MutableContextWrapper(context),
                     readingFontsPreference = readingFontsPreference,
                     webViewClient = webViewClient,
                     webChromeClient = webChromeClient,
@@ -74,7 +65,8 @@ object WebViewLayout {
         return webView
     }
 
-    fun release(webView: HorizontalScrollAwareWebView) {
+    fun recycle(webView: HorizontalScrollAwareWebView) {
+        (webView.webChromeClient as? RYWebChromeClient)?.releaseCustomView()
         (webView.parent as? android.view.ViewGroup)?.removeView(webView)
         webView.loadedContentKey = null
         webView.onScrollSnapshotChanged = null
@@ -88,7 +80,9 @@ object WebViewLayout {
         runCatching { webView.scrollTo(0, 0) }
         runCatching { webView.webChromeClient = null }
         runCatching { webView.webViewClient = android.webkit.WebViewClient() }
-        pooledWebView = webView
+        (webView.context as? MutableContextWrapper)?.baseContext = webView.context.applicationContext
+        retainedWebView?.let(::destroyRetainedWebView)
+        retainedWebView = webView
     }
 
     @SuppressLint("SetJavaScriptEnabled")
@@ -100,7 +94,7 @@ object WebViewLayout {
         onImageClick: ((imgUrl: String, altText: String) -> Unit)? = null,
         onLinkLongPress: ((url: String, text: String) -> Unit)? = null,
     ): HorizontalScrollAwareWebView =
-        acquire(
+        obtain(
             context = context,
             readingFontsPreference = readingFontsPreference,
             webViewClient = webViewClient,
@@ -108,6 +102,27 @@ object WebViewLayout {
             onImageClick = onImageClick,
             onLinkLongPress = onLinkLongPress,
         )
+
+    private fun buildRetainedWebView(
+        context: Context,
+        readingFontsPreference: ReadingFontsPreference,
+    ): HorizontalScrollAwareWebView =
+        createWebView(
+            context = MutableContextWrapper(context),
+            readingFontsPreference = readingFontsPreference,
+            webViewClient = android.webkit.WebViewClient(),
+            webChromeClient = null,
+            onImageClick = null,
+            onLinkLongPress = null,
+        ).also { webView ->
+            webView.loadDataWithBaseURL(
+                PREWARM_BASE_URL,
+                PREWARM_HTML,
+                "text/html",
+                "UTF-8",
+                null,
+            )
+        }
 
     @SuppressLint("SetJavaScriptEnabled")
     private fun createWebView(
@@ -188,5 +203,13 @@ object WebViewLayout {
                 isAlgorithmicDarkeningAllowed = true
             }
         }
+    }
+
+    private fun destroyRetainedWebView(webView: HorizontalScrollAwareWebView) {
+        (webView.parent as? android.view.ViewGroup)?.removeView(webView)
+        runCatching { webView.stopLoading() }
+        runCatching { webView.loadUrl("about:blank") }
+        runCatching { webView.removeAllViews() }
+        runCatching { webView.destroy() }
     }
 }

--- a/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/flow/FlowPage.kt
@@ -90,6 +90,7 @@ import me.ash.reader.infrastructure.preference.LocalFlowTopBarTonalElevation
 import me.ash.reader.infrastructure.preference.LocalMarkAsReadOnScroll
 import me.ash.reader.infrastructure.preference.LocalOpenLink
 import me.ash.reader.infrastructure.preference.LocalOpenLinkSpecificBrowser
+import me.ash.reader.infrastructure.preference.LocalReadingFonts
 import me.ash.reader.infrastructure.preference.LocalSettings
 import me.ash.reader.infrastructure.preference.LocalSharedContent
 import me.ash.reader.infrastructure.preference.PullToLoadNextFeedPreference
@@ -100,6 +101,7 @@ import me.ash.reader.ui.component.base.RYScaffold
 import me.ash.reader.ui.component.scrollbar.VerticalScrollIndicatorFactory
 import me.ash.reader.ui.component.scrollbar.drawVerticalScrollIndicator
 import me.ash.reader.ui.component.scrollbar.scrollIndicator
+import me.ash.reader.ui.component.webview.WebViewLayout
 import me.ash.reader.ui.ext.collectAsStateValue
 import me.ash.reader.ui.ext.openURL
 import me.ash.reader.ui.motion.Direction
@@ -137,6 +139,7 @@ fun FlowPage(
     val sharedContent = LocalSharedContent.current
     val markAsReadOnScroll = LocalMarkAsReadOnScroll.current.value
     val context = LocalContext.current
+    val readingFonts = LocalReadingFonts.current
     val markedAsReadMessage = stringResource(R.string.marked_as_read)
     val undoActionLabel = stringResource(R.string.undo)
 
@@ -148,6 +151,10 @@ fun FlowPage(
 
     val flowUiState = viewModel.flowUiState.collectAsStateValue()
     if (flowUiState == null) return
+
+    LaunchedEffect(context, readingFonts) {
+        WebViewLayout.prewarm(context, readingFonts)
+    }
 
     val pagerData: PagerData = flowUiState.pagerData
 

--- a/app/src/main/java/me/ash/reader/ui/page/home/reading/ReadingPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/reading/ReadingPage.kt
@@ -59,7 +59,9 @@ import me.ash.reader.ui.component.webview.WebViewScrollSnapshot
 import me.ash.reader.infrastructure.android.TextToSpeechManager
 import me.ash.reader.infrastructure.preference.LocalPullToSwitchArticle
 import me.ash.reader.infrastructure.preference.LocalReadingAutoHideToolbar
+import me.ash.reader.infrastructure.preference.LocalReadingFonts
 import me.ash.reader.infrastructure.preference.LocalReadingTextLineHeight
+import me.ash.reader.ui.component.webview.WebViewLayout
 import me.ash.reader.ui.ext.collectAsStateValue
 import me.ash.reader.ui.ext.showToast
 import me.ash.reader.ui.page.adaptive.ArticleListReaderViewModel
@@ -88,6 +90,7 @@ fun ReadingPage(
     onNavigateToStylePage: () -> Unit,
 ) {
     val context = LocalContext.current
+    val readingFonts = LocalReadingFonts.current
     val hapticFeedback = LocalHapticFeedback.current
     val density = LocalDensity.current
     val isPullToSwitchArticleEnabled = LocalPullToSwitchArticle.current.value
@@ -151,6 +154,11 @@ fun ReadingPage(
     )
 
     var showTopDivider by remember { mutableStateOf(false) }
+
+    DisposableEffect(context, readingFonts) {
+        WebViewLayout.prewarm(context, readingFonts)
+        onDispose {}
+    }
 
     //    LaunchedEffect(readerState.listIndex) {
     //        readerState.listIndex?.let {

--- a/app/src/main/java/me/ash/reader/ui/page/home/reading/ReadingPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/reading/ReadingPage.kt
@@ -59,9 +59,7 @@ import me.ash.reader.ui.component.webview.WebViewScrollSnapshot
 import me.ash.reader.infrastructure.android.TextToSpeechManager
 import me.ash.reader.infrastructure.preference.LocalPullToSwitchArticle
 import me.ash.reader.infrastructure.preference.LocalReadingAutoHideToolbar
-import me.ash.reader.infrastructure.preference.LocalReadingFonts
 import me.ash.reader.infrastructure.preference.LocalReadingTextLineHeight
-import me.ash.reader.ui.component.webview.WebViewLayout
 import me.ash.reader.ui.ext.collectAsStateValue
 import me.ash.reader.ui.ext.showToast
 import me.ash.reader.ui.page.adaptive.ArticleListReaderViewModel
@@ -90,7 +88,6 @@ fun ReadingPage(
     onNavigateToStylePage: () -> Unit,
 ) {
     val context = LocalContext.current
-    val readingFonts = LocalReadingFonts.current
     val hapticFeedback = LocalHapticFeedback.current
     val density = LocalDensity.current
     val isPullToSwitchArticleEnabled = LocalPullToSwitchArticle.current.value
@@ -154,11 +151,6 @@ fun ReadingPage(
     )
 
     var showTopDivider by remember { mutableStateOf(false) }
-
-    DisposableEffect(context, readingFonts) {
-        WebViewLayout.prewarm(context, readingFonts)
-        onDispose {}
-    }
 
     //    LaunchedEffect(readerState.listIndex) {
     //        readerState.listIndex?.let {


### PR DESCRIPTION
## Summary
- move reader WebView prewarm into the home/root flow so warmup starts before the first article is opened
- make prewarm perform a tiny real HTML load, which removes the remaining first-use WebView renderer/document startup cost
- simplify the earlier pool abstraction into a single retained warmed WebView that is rebound to the active `Activity` via `MutableContextWrapper`
- preserve protected subresource loading by restoring the 403 + `Referer` fallback for non-main-frame requests while keeping the short timeout guard

## Testing
- `./gradlew :app:compileGithubDebugKotlin`
- installed on emulator and manually verified: first article open is materially faster, and subsequent opens remain effectively instant