### PR TITLE
[codex] Keep archived articles by default for new accounts

### DIFF
--- a/app/schemas/me.ash.reader.infrastructure.db.AndroidDatabase/11.json
+++ b/app/schemas/me.ash.reader.infrastructure.db.AndroidDatabase/11.json
@@ -2,11 +2,11 @@
   "formatVersion": 1,
   "database": {
     "version": 11,
-    "identityHash": "6b56f18840d07309931d9a2181032aa7",
+    "identityHash": "871af344bbf2efe7d815f3a9a3b51ed4",
     "entities": [
       {
         "tableName": "account",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `name` TEXT NOT NULL, `type` INTEGER NOT NULL, `updateAt` INTEGER, `lastArticleId` TEXT, `syncInterval` INTEGER NOT NULL DEFAULT 30, `syncOnStart` INTEGER NOT NULL DEFAULT 0, `syncOnlyOnWiFi` INTEGER NOT NULL DEFAULT 0, `syncOnlyWhenCharging` INTEGER NOT NULL DEFAULT 0, `keepArchived` INTEGER NOT NULL DEFAULT 0, `syncBlockList` TEXT NOT NULL DEFAULT '', `securityKey` TEXT DEFAULT 'CvJ1PKM8EW8=')",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `name` TEXT NOT NULL, `type` INTEGER NOT NULL, `updateAt` INTEGER, `lastArticleId` TEXT, `syncInterval` INTEGER NOT NULL DEFAULT 30, `syncOnStart` INTEGER NOT NULL DEFAULT 0, `syncOnlyOnWiFi` INTEGER NOT NULL DEFAULT 0, `syncOnlyWhenCharging` INTEGER NOT NULL DEFAULT 0, `keepArchived` INTEGER NOT NULL DEFAULT 2592000000, `syncBlockList` TEXT NOT NULL DEFAULT '', `securityKey` TEXT DEFAULT 'CvJ1PKM8EW8=')",
         "fields": [
           {
             "fieldPath": "id",
@@ -68,7 +68,7 @@
             "columnName": "keepArchived",
             "affinity": "INTEGER",
             "notNull": true,
-            "defaultValue": "0"
+            "defaultValue": "2592000000"
           },
           {
             "fieldPath": "syncBlockList",
@@ -501,7 +501,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '6b56f18840d07309931d9a2181032aa7')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '871af344bbf2efe7d815f3a9a3b51ed4')"
     ]
   }
 }

--- a/app/schemas/me.ash.reader.infrastructure.db.AndroidDatabase/11.json
+++ b/app/schemas/me.ash.reader.infrastructure.db.AndroidDatabase/11.json
@@ -2,11 +2,11 @@
   "formatVersion": 1,
   "database": {
     "version": 11,
-    "identityHash": "871af344bbf2efe7d815f3a9a3b51ed4",
+    "identityHash": "6b56f18840d07309931d9a2181032aa7",
     "entities": [
       {
         "tableName": "account",
-        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `name` TEXT NOT NULL, `type` INTEGER NOT NULL, `updateAt` INTEGER, `lastArticleId` TEXT, `syncInterval` INTEGER NOT NULL DEFAULT 30, `syncOnStart` INTEGER NOT NULL DEFAULT 0, `syncOnlyOnWiFi` INTEGER NOT NULL DEFAULT 0, `syncOnlyWhenCharging` INTEGER NOT NULL DEFAULT 0, `keepArchived` INTEGER NOT NULL DEFAULT 2592000000, `syncBlockList` TEXT NOT NULL DEFAULT '', `securityKey` TEXT DEFAULT 'CvJ1PKM8EW8=')",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `name` TEXT NOT NULL, `type` INTEGER NOT NULL, `updateAt` INTEGER, `lastArticleId` TEXT, `syncInterval` INTEGER NOT NULL DEFAULT 30, `syncOnStart` INTEGER NOT NULL DEFAULT 0, `syncOnlyOnWiFi` INTEGER NOT NULL DEFAULT 0, `syncOnlyWhenCharging` INTEGER NOT NULL DEFAULT 0, `keepArchived` INTEGER NOT NULL DEFAULT 0, `syncBlockList` TEXT NOT NULL DEFAULT '', `securityKey` TEXT DEFAULT 'CvJ1PKM8EW8=')",
         "fields": [
           {
             "fieldPath": "id",
@@ -68,7 +68,7 @@
             "columnName": "keepArchived",
             "affinity": "INTEGER",
             "notNull": true,
-            "defaultValue": "2592000000"
+            "defaultValue": "0"
           },
           {
             "fieldPath": "syncBlockList",
@@ -501,7 +501,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '871af344bbf2efe7d815f3a9a3b51ed4')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '6b56f18840d07309931d9a2181032aa7')"
     ]
   }
 }

--- a/app/schemas/me.ash.reader.infrastructure.db.AndroidDatabase/12.json
+++ b/app/schemas/me.ash.reader.infrastructure.db.AndroidDatabase/12.json
@@ -1,0 +1,507 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 12,
+    "identityHash": "6b56f18840d07309931d9a2181032aa7",
+    "entities": [
+      {
+        "tableName": "account",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT, `name` TEXT NOT NULL, `type` INTEGER NOT NULL, `updateAt` INTEGER, `lastArticleId` TEXT, `syncInterval` INTEGER NOT NULL DEFAULT 30, `syncOnStart` INTEGER NOT NULL DEFAULT 0, `syncOnlyOnWiFi` INTEGER NOT NULL DEFAULT 0, `syncOnlyWhenCharging` INTEGER NOT NULL DEFAULT 0, `keepArchived` INTEGER NOT NULL DEFAULT 0, `syncBlockList` TEXT NOT NULL DEFAULT '', `securityKey` TEXT DEFAULT 'CvJ1PKM8EW8=')",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "type",
+            "columnName": "type",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updateAt",
+            "columnName": "updateAt",
+            "affinity": "INTEGER"
+          },
+          {
+            "fieldPath": "lastArticleId",
+            "columnName": "lastArticleId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "syncInterval",
+            "columnName": "syncInterval",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "30"
+          },
+          {
+            "fieldPath": "syncOnStart",
+            "columnName": "syncOnStart",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "syncOnlyOnWiFi",
+            "columnName": "syncOnlyOnWiFi",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "syncOnlyWhenCharging",
+            "columnName": "syncOnlyWhenCharging",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "keepArchived",
+            "columnName": "keepArchived",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "syncBlockList",
+            "columnName": "syncBlockList",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "''"
+          },
+          {
+            "fieldPath": "securityKey",
+            "columnName": "securityKey",
+            "affinity": "TEXT",
+            "defaultValue": "'CvJ1PKM8EW8='"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "feed",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `icon` TEXT, `url` TEXT NOT NULL, `groupId` TEXT NOT NULL, `accountId` INTEGER NOT NULL, `isNotification` INTEGER NOT NULL, `isFullContent` INTEGER NOT NULL, `isBrowser` INTEGER NOT NULL DEFAULT 0, `sortOrder` INTEGER DEFAULT NULL, PRIMARY KEY(`id`), FOREIGN KEY(`groupId`) REFERENCES `group`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "icon",
+            "columnName": "icon",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "groupId",
+            "columnName": "groupId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isNotification",
+            "columnName": "isNotification",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isFullContent",
+            "columnName": "isFullContent",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isBrowser",
+            "columnName": "isBrowser",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "sortOrder",
+            "columnName": "sortOrder",
+            "affinity": "INTEGER",
+            "defaultValue": "NULL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_feed_groupId",
+            "unique": false,
+            "columnNames": [
+              "groupId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_groupId` ON `${TABLE_NAME}` (`groupId`)"
+          },
+          {
+            "name": "index_feed_accountId",
+            "unique": false,
+            "columnNames": [
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_feed_accountId` ON `${TABLE_NAME}` (`accountId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "group",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "groupId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "article",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `date` INTEGER NOT NULL, `title` TEXT NOT NULL, `author` TEXT, `rawDescription` TEXT NOT NULL, `shortDescription` TEXT NOT NULL, `fullContent` TEXT, `img` TEXT, `link` TEXT NOT NULL, `feedId` TEXT NOT NULL, `accountId` INTEGER NOT NULL, `isUnread` INTEGER NOT NULL, `isStarred` INTEGER NOT NULL, `isReadLater` INTEGER NOT NULL, `updateAt` INTEGER, PRIMARY KEY(`id`), FOREIGN KEY(`feedId`) REFERENCES `feed`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "author",
+            "columnName": "author",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "rawDescription",
+            "columnName": "rawDescription",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "shortDescription",
+            "columnName": "shortDescription",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "fullContent",
+            "columnName": "fullContent",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "img",
+            "columnName": "img",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "link",
+            "columnName": "link",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feedId",
+            "columnName": "feedId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnread",
+            "columnName": "isUnread",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isStarred",
+            "columnName": "isStarred",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isReadLater",
+            "columnName": "isReadLater",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updateAt",
+            "columnName": "updateAt",
+            "affinity": "INTEGER"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_article_feedId",
+            "unique": false,
+            "columnNames": [
+              "feedId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_article_feedId` ON `${TABLE_NAME}` (`feedId`)"
+          },
+          {
+            "name": "index_article_accountId",
+            "unique": false,
+            "columnNames": [
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_article_accountId` ON `${TABLE_NAME}` (`accountId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "feed",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "feedId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "group",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `accountId` INTEGER NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_group_accountId",
+            "unique": false,
+            "columnNames": [
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_group_accountId` ON `${TABLE_NAME}` (`accountId`)"
+          }
+        ]
+      },
+      {
+        "tableName": "archived_article",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `feedId` TEXT NOT NULL, `link` TEXT NOT NULL, FOREIGN KEY(`feedId`) REFERENCES `feed`(`id`) ON UPDATE CASCADE ON DELETE CASCADE )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feedId",
+            "columnName": "feedId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "link",
+            "columnName": "link",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_archived_article_feedId",
+            "unique": false,
+            "columnNames": [
+              "feedId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_archived_article_feedId` ON `${TABLE_NAME}` (`feedId`)"
+          }
+        ],
+        "foreignKeys": [
+          {
+            "table": "feed",
+            "onDelete": "CASCADE",
+            "onUpdate": "CASCADE",
+            "columns": [
+              "feedId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "pending_read_state_op",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`articleId` TEXT NOT NULL, `accountId` INTEGER NOT NULL, `feedId` TEXT NOT NULL, `isUnread` INTEGER NOT NULL, `updatedAt` INTEGER NOT NULL, `localCommitted` INTEGER NOT NULL DEFAULT 0, `remoteSynced` INTEGER NOT NULL DEFAULT 0, PRIMARY KEY(`articleId`))",
+        "fields": [
+          {
+            "fieldPath": "articleId",
+            "columnName": "articleId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "accountId",
+            "columnName": "accountId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "feedId",
+            "columnName": "feedId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isUnread",
+            "columnName": "isUnread",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updatedAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "localCommitted",
+            "columnName": "localCommitted",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "remoteSynced",
+            "columnName": "remoteSynced",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "articleId"
+          ]
+        },
+        "indices": [
+          {
+            "name": "index_pending_read_state_op_accountId",
+            "unique": false,
+            "columnNames": [
+              "accountId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pending_read_state_op_accountId` ON `${TABLE_NAME}` (`accountId`)"
+          },
+          {
+            "name": "index_pending_read_state_op_feedId",
+            "unique": false,
+            "columnNames": [
+              "feedId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_pending_read_state_op_feedId` ON `${TABLE_NAME}` (`feedId`)"
+          }
+        ]
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '6b56f18840d07309931d9a2181032aa7')"
+    ]
+  }
+}

--- a/app/src/main/java/me/ash/reader/domain/model/account/Account.kt
+++ b/app/src/main/java/me/ash/reader/domain/model/account/Account.kt
@@ -31,7 +31,7 @@ data class Account(
     val syncOnlyOnWiFi: SyncOnlyOnWiFiPreference = SyncOnlyOnWiFiPreference.default,
     @field:ColumnInfo(defaultValue = "0")
     val syncOnlyWhenCharging: SyncOnlyWhenChargingPreference = SyncOnlyWhenChargingPreference.default,
-    @field:ColumnInfo(defaultValue = "2592000000")
+    @field:ColumnInfo(defaultValue = "0")
     val keepArchived: KeepArchivedPreference = KeepArchivedPreference.default,
     @field:ColumnInfo(defaultValue = "")
     val syncBlockList: SyncBlockList = SyncBlockListPreference.default,

--- a/app/src/main/java/me/ash/reader/domain/service/SyncWorker.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/SyncWorker.kt
@@ -29,6 +29,7 @@ constructor(
         val feedId = data.getString("feedId")
         val groupId = data.getString("groupId")
         val excludedReadStateIds = diffMapHolder.prepareReadStateForSync(accountId)
+        val isPeriodicRun = tags.contains(PERIODIC_WORK_TAG)
 
         return rssService
             .get()
@@ -39,8 +40,10 @@ constructor(
                 excludedReadStateIds = excludedReadStateIds,
             )
             .also {
-                rssService.get().clearKeepArchivedArticles().forEach {
-                    readerCacheHelper.deleteCacheFor(articleId = it.id)
+                if (isPeriodicRun) {
+                    rssService.get().clearKeepArchivedArticles().forEach {
+                        readerCacheHelper.deleteCacheFor(articleId = it.id)
+                    }
                 }
                 workManager
                     .beginUniqueWork(

--- a/app/src/main/java/me/ash/reader/domain/service/SyncWorker.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/SyncWorker.kt
@@ -8,7 +8,6 @@ import dagger.assisted.AssistedInject
 import java.util.concurrent.TimeUnit
 import me.ash.reader.domain.data.DiffMapHolder
 import me.ash.reader.domain.model.account.Account
-import me.ash.reader.infrastructure.rss.ReaderCacheHelper
 
 @HiltWorker
 class SyncWorker
@@ -18,7 +17,6 @@ constructor(
     @Assisted workerParams: WorkerParameters,
     private val rssService: RssService,
     private val diffMapHolder: DiffMapHolder,
-    private val readerCacheHelper: ReaderCacheHelper,
     private val workManager: WorkManager,
 ) : CoroutineWorker(context, workerParams) {
 
@@ -29,7 +27,6 @@ constructor(
         val feedId = data.getString("feedId")
         val groupId = data.getString("groupId")
         val excludedReadStateIds = diffMapHolder.prepareReadStateForSync(accountId)
-        val isPeriodicRun = tags.contains(PERIODIC_WORK_TAG)
 
         return rssService
             .get()
@@ -40,11 +37,6 @@ constructor(
                 excludedReadStateIds = excludedReadStateIds,
             )
             .also {
-                if (isPeriodicRun) {
-                    rssService.get().clearKeepArchivedArticles().forEach {
-                        readerCacheHelper.deleteCacheFor(articleId = it.id)
-                    }
-                }
                 workManager
                     .beginUniqueWork(
                         uniqueWorkName = POST_SYNC_WORK_NAME,

--- a/app/src/main/java/me/ash/reader/infrastructure/android/AndroidApp.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/android/AndroidApp.kt
@@ -26,6 +26,7 @@ import me.ash.reader.infrastructure.di.IODispatcher
 import me.ash.reader.infrastructure.net.NetworkDataSource
 import me.ash.reader.infrastructure.preference.SettingsProvider
 import me.ash.reader.infrastructure.rss.OPMLDataSource
+import me.ash.reader.infrastructure.rss.ReaderCacheHelper
 import me.ash.reader.infrastructure.rss.RssHelper
 import me.ash.reader.ui.ext.del
 import me.ash.reader.ui.ext.getLatestApk
@@ -87,6 +88,8 @@ class AndroidApp : Application(), Configuration.Provider {
 
     @Inject lateinit var diffMapHolder: DiffMapHolder
 
+    @Inject lateinit var readerCacheHelper: ReaderCacheHelper
+
     /**
      * When the application startup.
      * 1. Set the uncaught exception handler
@@ -131,6 +134,15 @@ class AndroidApp : Application(), Configuration.Provider {
 
     private suspend fun workerInit() {
         rssService.get().initSync()
+        applicationScope.launch(ioDispatcher) {
+            runCatching {
+                rssService.get().clearKeepArchivedArticles().forEach {
+                    readerCacheHelper.deleteCacheFor(articleId = it.id)
+                }
+            }.onFailure {
+                Timber.w(it, "Startup archive cleanup failed")
+            }
+        }
     }
 
     private suspend fun repairCurrentAccountData() {

--- a/app/src/main/java/me/ash/reader/infrastructure/db/AndroidDatabase.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/db/AndroidDatabase.kt
@@ -138,7 +138,7 @@ object MIGRATION_2_3 : Migration(2, 3) {
         )
         db.execSQL(
             """
-            ALTER TABLE account ADD COLUMN keepArchived INTEGER NOT NULL DEFAULT ${KeepArchivedPreference.default.value}
+            ALTER TABLE account ADD COLUMN keepArchived INTEGER NOT NULL DEFAULT 2592000000
             """.trimIndent()
         )
         db.execSQL(

--- a/app/src/main/java/me/ash/reader/infrastructure/db/AndroidDatabase.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/db/AndroidDatabase.kt
@@ -29,7 +29,7 @@ import java.util.*
         ArchivedArticle::class,
         PendingReadStateOp::class,
     ],
-    version = 11,
+    version = 12,
     autoMigrations = [
         AutoMigration(from = 5, to = 6),
         AutoMigration(from = 6, to = 7),
@@ -93,6 +93,7 @@ val allMigrations = arrayOf(
     MIGRATION_3_4,
     MIGRATION_4_5,
     MIGRATION_10_11,
+    MIGRATION_11_12,
 )
 
 @Suppress("ClassName")
@@ -197,5 +198,64 @@ object MIGRATION_10_11 : Migration(10, 11) {
             )
             """.trimIndent()
         )
+    }
+}
+
+@Suppress("ClassName")
+object MIGRATION_11_12 : Migration(11, 12) {
+
+    override fun migrate(db: SupportSQLiteDatabase) {
+        db.execSQL(
+            """
+            CREATE TABLE IF NOT EXISTS `account_new` (
+                `id` INTEGER PRIMARY KEY AUTOINCREMENT,
+                `name` TEXT NOT NULL,
+                `type` INTEGER NOT NULL,
+                `updateAt` INTEGER,
+                `lastArticleId` TEXT,
+                `syncInterval` INTEGER NOT NULL DEFAULT 30,
+                `syncOnStart` INTEGER NOT NULL DEFAULT 0,
+                `syncOnlyOnWiFi` INTEGER NOT NULL DEFAULT 0,
+                `syncOnlyWhenCharging` INTEGER NOT NULL DEFAULT 0,
+                `keepArchived` INTEGER NOT NULL DEFAULT 0,
+                `syncBlockList` TEXT NOT NULL DEFAULT '',
+                `securityKey` TEXT DEFAULT '${DESUtils.empty}'
+            )
+            """.trimIndent()
+        )
+        db.execSQL(
+            """
+            INSERT INTO `account_new` (
+                `id`,
+                `name`,
+                `type`,
+                `updateAt`,
+                `lastArticleId`,
+                `syncInterval`,
+                `syncOnStart`,
+                `syncOnlyOnWiFi`,
+                `syncOnlyWhenCharging`,
+                `keepArchived`,
+                `syncBlockList`,
+                `securityKey`
+            )
+            SELECT
+                `id`,
+                `name`,
+                `type`,
+                `updateAt`,
+                `lastArticleId`,
+                `syncInterval`,
+                `syncOnStart`,
+                `syncOnlyOnWiFi`,
+                `syncOnlyWhenCharging`,
+                `keepArchived`,
+                `syncBlockList`,
+                `securityKey`
+            FROM `account`
+            """.trimIndent()
+        )
+        db.execSQL("DROP TABLE `account`")
+        db.execSQL("ALTER TABLE `account_new` RENAME TO `account`")
     }
 }

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/KeepArchivedPreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/KeepArchivedPreference.kt
@@ -33,7 +33,7 @@ sealed class KeepArchivedPreference(
 
     companion object {
 
-        val default = For1Month
+        val default = Always
         val values = listOf(
             Always,
             For1Day,


### PR DESCRIPTION
## Summary
- default `keepArchived` to `Always` for newly created accounts
- keep manual sync from triggering archive cleanup, limiting cleanup to periodic sync housekeeping
- leave existing account retention settings unchanged

## Root cause
Manual pull-to-sync was sharing the same archive cleanup path as periodic sync. When a user marked an older article as read and then manually synced, archive retention could delete that article as part of the same flow, which made the disappearance look like a sync failure regression.

## Validation
- `./gradlew testGithubDebugUnitTest --tests me.ash.reader.domain.service.GoogleReaderReadStateReconcilerTest --tests me.ash.reader.domain.data.DiffMapHolderPendingReadStateTest`

Closes #100