### PR TITLE
[codex] fix offline unsubscribe crash

### DIFF
--- a/app/src/main/java/me/ash/reader/ui/page/home/feeds/drawer/feed/DeleteFeedDialog.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/feeds/drawer/feed/DeleteFeedDialog.kt
@@ -6,7 +6,6 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
 import androidx.hilt.lifecycle.viewmodel.compose.hiltViewModel
@@ -23,8 +22,8 @@ fun DeleteFeedDialog(
 ) {
     val context = LocalContext.current
     val feedOptionUiState = feedOptionViewModel.feedOptionUiState.collectAsStateValue()
-    val scope = rememberCoroutineScope()
     val toastString = stringResource(R.string.delete_toast, feedName)
+    val errorToast = stringResource(R.string.server_unreachable)
 
     RYDialog(
         visible = feedOptionUiState.deleteDialogVisible,
@@ -46,11 +45,16 @@ fun DeleteFeedDialog(
         confirmButton = {
             TextButton(
                 onClick = {
-                    feedOptionViewModel.delete {
-                        feedOptionViewModel.hideDeleteDialog()
-                        onConfirm()
-                        context.showToast(toastString)
-                    }
+                    feedOptionViewModel.delete(
+                        onSuccess = {
+                            feedOptionViewModel.hideDeleteDialog()
+                            onConfirm()
+                            context.showToast(toastString)
+                        },
+                        onFailure = {
+                            context.showToast(errorToast)
+                        },
+                    )
                 }
             ) {
                 Text(

--- a/app/src/main/java/me/ash/reader/ui/page/home/feeds/drawer/feed/FeedOptionViewModel.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/feeds/drawer/feed/FeedOptionViewModel.kt
@@ -22,6 +22,7 @@ import me.ash.reader.infrastructure.di.ApplicationScope
 import me.ash.reader.infrastructure.di.IODispatcher
 import me.ash.reader.infrastructure.di.MainDispatcher
 import me.ash.reader.infrastructure.rss.RssHelper
+import timber.log.Timber
 
 @OptIn(ExperimentalMaterialApi::class)
 @HiltViewModel
@@ -128,11 +129,20 @@ constructor(
         }
     }
 
-    fun delete(callback: () -> Unit = {}) {
+    fun delete(
+        onSuccess: () -> Unit = {},
+        onFailure: (Throwable) -> Unit = {},
+    ) {
         _feedOptionUiState.value.feed?.let {
             applicationScope.launch(ioDispatcher) {
-                rssService.get().deleteFeed(it)
-                withContext(mainDispatcher) { callback() }
+                runCatching {
+                    rssService.get().deleteFeed(it)
+                }.onSuccess {
+                    withContext(mainDispatcher) { onSuccess() }
+                }.onFailure { throwable ->
+                    Timber.tag("RLog").w(throwable, "Failed to unsubscribe feed ${it.id}")
+                    withContext(mainDispatcher) { onFailure(throwable) }
+                }
             }
         }
     }

--- a/app/src/test/java/me/ash/reader/ui/page/home/feeds/drawer/feed/FeedOptionViewModelTest.kt
+++ b/app/src/test/java/me/ash/reader/ui/page/home/feeds/drawer/feed/FeedOptionViewModelTest.kt
@@ -1,0 +1,75 @@
+package me.ash.reader.ui.page.home.feeds.drawer.feed
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withTimeout
+import me.ash.reader.domain.model.feed.Feed
+import me.ash.reader.domain.repository.FeedDao
+import me.ash.reader.domain.service.AbstractRssRepository
+import me.ash.reader.domain.service.RssService
+import me.ash.reader.infrastructure.rss.RssHelper
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertSame
+import org.junit.Test
+import org.mockito.kotlin.any
+import org.mockito.kotlin.mock
+import org.mockito.kotlin.whenever
+
+class FeedOptionViewModelTest {
+
+    @Test
+    fun `delete reports failure instead of invoking success when unsubscribe throws`() = runBlocking {
+        val feed = sampleFeed()
+        val repository = mock<AbstractRssRepository>()
+        val rssService = mock<RssService>()
+        val failure = IllegalStateException("offline")
+
+        whenever(rssService.get()).thenReturn(repository)
+        whenever(rssService.flow()).thenReturn(MutableStateFlow(repository))
+        whenever(repository.pullGroups()).thenReturn(flowOf(mutableListOf()))
+        whenever(repository.findFeedById(feed.id)).thenReturn(feed)
+        whenever(repository.deleteFeed(any(), any())).thenThrow(failure)
+
+        val viewModel =
+            FeedOptionViewModel(
+                rssService = rssService,
+                mainDispatcher = Dispatchers.Unconfined,
+                ioDispatcher = Dispatchers.Unconfined,
+                applicationScope = CoroutineScope(SupervisorJob() + Dispatchers.Unconfined),
+                rssHelper = mock<RssHelper>(),
+                feedDao = mock<FeedDao>(),
+            )
+
+        viewModel.fetchFeed(feed.id)
+
+        var successCalled = false
+        var reportedFailure: Throwable? = null
+
+        viewModel.delete(
+            onSuccess = { successCalled = true },
+            onFailure = { reportedFailure = it },
+        )
+
+        withTimeout(1_000) {
+            while (reportedFailure == null) {
+                kotlinx.coroutines.yield()
+            }
+        }
+
+        assertFalse(successCalled)
+        assertSame(failure, reportedFailure)
+    }
+
+    private fun sampleFeed(): Feed =
+        Feed(
+            id = "account\$feed",
+            name = "Feed",
+            url = "https://example.com/feed",
+            groupId = "group",
+            accountId = 1,
+        )
+}


### PR DESCRIPTION
## Summary
- catch feed unsubscribe failures in `FeedOptionViewModel` instead of letting the coroutine crash the app
- show a server-unreachable toast from the unsubscribe dialog when the remote delete fails
- add a unit test that verifies the failure callback runs and the success callback does not

## Root Cause
The unsubscribe flow called the remote `subscriptionEdit(...unsubscribe...)` path without handling exceptions. When the server was offline, the thrown exception bubbled out of the launched coroutine and crashed the app.

## Validation
- `./gradlew :app:testGithubDebugUnitTest --tests me.ash.reader.ui.page.home.feeds.drawer.feed.FeedOptionViewModelTest`

Closes #102.
