### PR TITLE
fix(sync): defer periodic sync while reading

### DIFF
--- a/app/src/main/java/me/ash/reader/domain/service/SyncWorker.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/SyncWorker.kt
@@ -23,9 +23,11 @@ constructor(
 ) : CoroutineWorker(context, workerParams) {
 
     override suspend fun doWork(): Result {
-        if (tags.contains(PERIODIC_WORK_TAG) && ForegroundSyncController.shouldDeferPeriodicSync()) {
-            Timber.tag(TAG).d("Deferring periodic sync while reader is active")
-            ForegroundSyncController.markDeferredPeriodicSyncPending()
+        if (
+            tags.contains(PERIODIC_WORK_TAG) &&
+                ForegroundSyncController.tryRecordMissedPeriodicSync()
+        ) {
+            Timber.tag(TAG).d("Deferring periodic sync tick while reader is active")
             return Result.success()
         }
 
@@ -71,6 +73,7 @@ constructor(
         private const val POST_SYNC_WORK_NAME = "POST_SYNC_WORK"
 
         private const val SYNC_ONETIME_NAME = "SYNC_ONETIME"
+        private const val SYNC_DEFERRED_PERIODIC_NAME = "SYNC_DEFERRED_PERIODIC"
 
         const val SYNC_TAG = "SYNC_TAG"
         const val READER_TAG = "READER_TAG"
@@ -114,10 +117,28 @@ constructor(
                 .enqueue()
         }
 
+        fun enqueueDeferredPeriodicCatchUpWork(account: Account, workManager: WorkManager) {
+            workManager
+                .beginUniqueWork(
+                    SYNC_DEFERRED_PERIODIC_NAME,
+                    ExistingWorkPolicy.REPLACE,
+                    OneTimeWorkRequestBuilder<SyncWorker>()
+                        .setConstraints(buildPeriodicConstraints(account))
+                        .setBackoffCriteria(
+                            backoffPolicy = BackoffPolicy.EXPONENTIAL,
+                            backoffDelay = 30,
+                            timeUnit = TimeUnit.SECONDS,
+                        )
+                        .setInputData(workDataOf("accountId" to account.id))
+                        .addTag(SYNC_TAG)
+                        .addTag(PERIODIC_WORK_TAG)
+                        .build(),
+                )
+                .enqueue()
+        }
+
         fun enqueuePeriodicWork(account: Account, workManager: WorkManager) {
             val syncInterval = account.syncInterval
-            val syncOnlyWhenCharging = account.syncOnlyWhenCharging
-            val syncOnlyOnWiFi = account.syncOnlyOnWiFi
             val workState =
                 workManager
                     .getWorkInfosForUniqueWork(SYNC_WORK_NAME_PERIODIC)
@@ -134,15 +155,7 @@ constructor(
                 SYNC_WORK_NAME_PERIODIC,
                 policy,
                 PeriodicWorkRequestBuilder<SyncWorker>(syncInterval.value, TimeUnit.MINUTES)
-                    .setConstraints(
-                        Constraints.Builder()
-                            .setRequiresCharging(syncOnlyWhenCharging.value)
-                            .setRequiredNetworkType(
-                                if (syncOnlyOnWiFi.value) NetworkType.UNMETERED
-                                else NetworkType.CONNECTED
-                            )
-                            .build()
-                    )
+                    .setConstraints(buildPeriodicConstraints(account))
                     .setBackoffCriteria(
                         backoffPolicy = BackoffPolicy.EXPONENTIAL,
                         backoffDelay = 30,
@@ -157,5 +170,13 @@ constructor(
 
             workManager.cancelUniqueWork(LEGACY_READER_WORK_NAME_PERIODIC)
         }
+
+        private fun buildPeriodicConstraints(account: Account): Constraints =
+            Constraints.Builder()
+                .setRequiresCharging(account.syncOnlyWhenCharging.value)
+                .setRequiredNetworkType(
+                    if (account.syncOnlyOnWiFi.value) NetworkType.UNMETERED else NetworkType.CONNECTED
+                )
+                .build()
     }
 }

--- a/app/src/main/java/me/ash/reader/domain/service/SyncWorker.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/SyncWorker.kt
@@ -8,6 +8,8 @@ import dagger.assisted.AssistedInject
 import java.util.concurrent.TimeUnit
 import me.ash.reader.domain.data.DiffMapHolder
 import me.ash.reader.domain.model.account.Account
+import me.ash.reader.infrastructure.android.ForegroundSyncController
+import timber.log.Timber
 
 @HiltWorker
 class SyncWorker
@@ -21,6 +23,12 @@ constructor(
 ) : CoroutineWorker(context, workerParams) {
 
     override suspend fun doWork(): Result {
+        if (tags.contains(PERIODIC_WORK_TAG) && ForegroundSyncController.shouldDeferPeriodicSync()) {
+            Timber.tag(TAG).d("Deferring periodic sync while reader is active")
+            ForegroundSyncController.markDeferredPeriodicSyncPending()
+            return Result.success()
+        }
+
         val data = inputData
         val accountId = data.getInt("accountId", -1)
         require(accountId != -1)
@@ -57,6 +65,7 @@ constructor(
     }
 
     companion object {
+        private const val TAG = "SyncWorker"
         private const val SYNC_WORK_NAME_PERIODIC = "ReadYou"
         private const val LEGACY_READER_WORK_NAME_PERIODIC = "FETCH_FULL_CONTENT_PERIODIC"
         private const val POST_SYNC_WORK_NAME = "POST_SYNC_WORK"

--- a/app/src/main/java/me/ash/reader/domain/service/SyncWorker.kt
+++ b/app/src/main/java/me/ash/reader/domain/service/SyncWorker.kt
@@ -86,6 +86,7 @@ constructor(
 
         fun cancelPeriodicWork(workManager: WorkManager) {
             workManager.cancelUniqueWork(SYNC_WORK_NAME_PERIODIC)
+            workManager.cancelUniqueWork(SYNC_DEFERRED_PERIODIC_NAME)
             workManager.cancelUniqueWork(LEGACY_READER_WORK_NAME_PERIODIC)
         }
 

--- a/app/src/main/java/me/ash/reader/infrastructure/android/ForegroundSyncController.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/android/ForegroundSyncController.kt
@@ -1,0 +1,42 @@
+package me.ash.reader.infrastructure.android
+
+import java.util.concurrent.atomic.AtomicBoolean
+import timber.log.Timber
+
+/**
+ * Tracks whether periodic sync should be deferred while the user is actively reading.
+ */
+object ForegroundSyncController {
+    @Volatile private var appInForeground = false
+    @Volatile private var readerActive = false
+
+    private val deferredPeriodicSyncPending = AtomicBoolean(false)
+
+    fun updateAppInForeground(inForeground: Boolean) {
+        appInForeground = inForeground
+        Timber.tag(TAG).d("updateAppInForeground($inForeground)")
+    }
+
+    fun updateReaderActive(active: Boolean) {
+        readerActive = active
+        Timber.tag(TAG).d("updateReaderActive($active)")
+    }
+
+    fun shouldDeferPeriodicSync(): Boolean = appInForeground && readerActive
+
+    fun markDeferredPeriodicSyncPending() {
+        deferredPeriodicSyncPending.set(true)
+        Timber.tag(TAG).d("markDeferredPeriodicSyncPending()")
+    }
+
+    fun consumeDeferredPeriodicSyncIfReady(): Boolean =
+        if (!shouldDeferPeriodicSync()) deferredPeriodicSyncPending.getAndSet(false) else false
+
+    internal fun resetForTest() {
+        appInForeground = false
+        readerActive = false
+        deferredPeriodicSyncPending.set(false)
+    }
+
+    private const val TAG = "ForegroundSync"
+}

--- a/app/src/main/java/me/ash/reader/infrastructure/android/ForegroundSyncController.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/android/ForegroundSyncController.kt
@@ -1,41 +1,53 @@
 package me.ash.reader.infrastructure.android
 
-import java.util.concurrent.atomic.AtomicBoolean
 import timber.log.Timber
 
 /**
- * Tracks whether periodic sync should be deferred while the user is actively reading.
+ * Tracks whether a periodic sync tick was missed while the user was actively reading.
  */
 object ForegroundSyncController {
-    @Volatile private var appInForeground = false
-    @Volatile private var readerActive = false
+    private var appInForeground = false
+    private var readerActive = false
 
-    private val deferredPeriodicSyncPending = AtomicBoolean(false)
+    private var missedPeriodicSyncPending = false
 
+    @Synchronized
     fun updateAppInForeground(inForeground: Boolean) {
         appInForeground = inForeground
         Timber.tag(TAG).d("updateAppInForeground($inForeground)")
     }
 
+    @Synchronized
     fun updateReaderActive(active: Boolean) {
         readerActive = active
         Timber.tag(TAG).d("updateReaderActive($active)")
     }
 
-    fun shouldDeferPeriodicSync(): Boolean = appInForeground && readerActive
+    @Synchronized fun shouldDeferPeriodicSync(): Boolean = appInForeground && readerActive
 
-    fun markDeferredPeriodicSyncPending() {
-        deferredPeriodicSyncPending.set(true)
-        Timber.tag(TAG).d("markDeferredPeriodicSyncPending()")
+    @Synchronized
+    fun tryRecordMissedPeriodicSync(): Boolean {
+        if (!shouldDeferPeriodicSync()) return false
+
+        missedPeriodicSyncPending = true
+        Timber.tag(TAG).d("tryRecordMissedPeriodicSync(): missed tick recorded")
+        return true
     }
 
+    @Synchronized
     fun consumeDeferredPeriodicSyncIfReady(): Boolean =
-        if (!shouldDeferPeriodicSync()) deferredPeriodicSyncPending.getAndSet(false) else false
+        if (!shouldDeferPeriodicSync() && missedPeriodicSyncPending) {
+            missedPeriodicSyncPending = false
+            true
+        } else {
+            false
+        }
 
+    @Synchronized
     internal fun resetForTest() {
         appInForeground = false
         readerActive = false
-        deferredPeriodicSyncPending.set(false)
+        missedPeriodicSyncPending = false
     }
 
     private const val TAG = "ForegroundSync"

--- a/app/src/main/java/me/ash/reader/infrastructure/android/MainActivity.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/android/MainActivity.kt
@@ -23,7 +23,6 @@ import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.profileinstaller.ProfileInstallerInitializer
 import androidx.work.WorkManager
-import androidx.work.workDataOf
 import coil.ImageLoader
 import dagger.hilt.android.AndroidEntryPoint
 import java.lang.reflect.Field
@@ -248,10 +247,10 @@ class MainActivity : AppCompatActivity() {
     private fun drainDeferredPeriodicSync() {
         if (!ForegroundSyncController.consumeDeferredPeriodicSyncIfReady()) return
 
-        SyncWorker.enqueueOneTimeWork(
-            workManager = workManager,
-            inputData = workDataOf("accountId" to accountService.getCurrentAccountId()),
-        )
+        val account = accountService.getCurrentAccount()
+        if (account.id == null || account.id == -1) return
+
+        SyncWorker.enqueueDeferredPeriodicCatchUpWork(account = account, workManager = workManager)
     }
 }
 

--- a/app/src/main/java/me/ash/reader/infrastructure/android/MainActivity.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/android/MainActivity.kt
@@ -12,6 +12,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.appcompat.app.AppCompatActivity
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.core.app.NotificationManagerCompat
@@ -22,6 +23,7 @@ import androidx.navigation3.runtime.NavKey
 import androidx.navigation3.runtime.rememberNavBackStack
 import androidx.profileinstaller.ProfileInstallerInitializer
 import androidx.work.WorkManager
+import androidx.work.workDataOf
 import coil.ImageLoader
 import dagger.hilt.android.AndroidEntryPoint
 import java.lang.reflect.Field
@@ -30,6 +32,7 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import me.ash.reader.domain.data.FilterStateUseCase
 import me.ash.reader.domain.service.AccountService
+import me.ash.reader.domain.service.SyncWorker
 import me.ash.reader.domain.service.WidgetUpdateWorker
 import me.ash.reader.infrastructure.compose.ProvideCompositionLocals
 import me.ash.reader.infrastructure.preference.AccountSettingsProvider
@@ -138,11 +141,29 @@ class MainActivity : AppCompatActivity() {
 
                             val backStack = rememberNavBackStack(*startDestination.toTypedArray())
 
+                            ReadingSyncEffect(backStack)
                             NewIntentHandlerEffect(backStack, subscribeViewModel)
                             AppEntry(backStack)
                         }
                     }
                 }
+            }
+        }
+    }
+
+    @Composable
+    private fun ReadingSyncEffect(backStack: NavBackStack<NavKey>) {
+        val isReadingRouteActive = backStack.lastOrNull() is Route.Reading
+
+        LaunchedEffect(isReadingRouteActive) {
+            ForegroundSyncController.updateReaderActive(isReadingRouteActive)
+            drainDeferredPeriodicSync()
+        }
+
+        DisposableEffect(Unit) {
+            onDispose {
+                ForegroundSyncController.updateReaderActive(false)
+                drainDeferredPeriodicSync()
             }
         }
     }
@@ -212,8 +233,25 @@ class MainActivity : AppCompatActivity() {
     }
 
     override fun onResume() {
+        ForegroundSyncController.updateAppInForeground(true)
+        drainDeferredPeriodicSync()
         WidgetUpdateWorker.enqueueOneTimeWork(workManager)
         super.onResume()
+    }
+
+    override fun onPause() {
+        ForegroundSyncController.updateAppInForeground(false)
+        drainDeferredPeriodicSync()
+        super.onPause()
+    }
+
+    private fun drainDeferredPeriodicSync() {
+        if (!ForegroundSyncController.consumeDeferredPeriodicSyncIfReady()) return
+
+        SyncWorker.enqueueOneTimeWork(
+            workManager = workManager,
+            inputData = workDataOf("accountId" to accountService.getCurrentAccountId()),
+        )
     }
 }
 

--- a/app/src/test/java/me/ash/reader/infrastructure/android/ForegroundSyncControllerTest.kt
+++ b/app/src/test/java/me/ash/reader/infrastructure/android/ForegroundSyncControllerTest.kt
@@ -24,10 +24,22 @@ class ForegroundSyncControllerTest {
     }
 
     @Test
+    fun `missed periodic sync is recorded only while app is foreground and reader is active`() {
+        assertFalse(ForegroundSyncController.tryRecordMissedPeriodicSync())
+
+        ForegroundSyncController.updateAppInForeground(true)
+        assertFalse(ForegroundSyncController.tryRecordMissedPeriodicSync())
+
+        ForegroundSyncController.updateAppInForeground(true)
+        ForegroundSyncController.updateReaderActive(true)
+        assertTrue(ForegroundSyncController.tryRecordMissedPeriodicSync())
+    }
+
+    @Test
     fun `deferred periodic sync is consumed after leaving the reader`() {
         ForegroundSyncController.updateAppInForeground(true)
         ForegroundSyncController.updateReaderActive(true)
-        ForegroundSyncController.markDeferredPeriodicSyncPending()
+        assertTrue(ForegroundSyncController.tryRecordMissedPeriodicSync())
 
         assertFalse(ForegroundSyncController.consumeDeferredPeriodicSyncIfReady())
 
@@ -40,7 +52,7 @@ class ForegroundSyncControllerTest {
     fun `deferred periodic sync is consumed after app leaves foreground`() {
         ForegroundSyncController.updateAppInForeground(true)
         ForegroundSyncController.updateReaderActive(true)
-        ForegroundSyncController.markDeferredPeriodicSyncPending()
+        assertTrue(ForegroundSyncController.tryRecordMissedPeriodicSync())
 
         ForegroundSyncController.updateAppInForeground(false)
 

--- a/app/src/test/java/me/ash/reader/infrastructure/android/ForegroundSyncControllerTest.kt
+++ b/app/src/test/java/me/ash/reader/infrastructure/android/ForegroundSyncControllerTest.kt
@@ -1,0 +1,49 @@
+package me.ash.reader.infrastructure.android
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class ForegroundSyncControllerTest {
+    @Before
+    fun setUp() {
+        ForegroundSyncController.resetForTest()
+    }
+
+    @Test
+    fun `periodic sync is deferred only while app is foreground and reader is active`() {
+        ForegroundSyncController.updateAppInForeground(true)
+        assertFalse(ForegroundSyncController.shouldDeferPeriodicSync())
+
+        ForegroundSyncController.updateReaderActive(true)
+        assertTrue(ForegroundSyncController.shouldDeferPeriodicSync())
+
+        ForegroundSyncController.updateAppInForeground(false)
+        assertFalse(ForegroundSyncController.shouldDeferPeriodicSync())
+    }
+
+    @Test
+    fun `deferred periodic sync is consumed after leaving the reader`() {
+        ForegroundSyncController.updateAppInForeground(true)
+        ForegroundSyncController.updateReaderActive(true)
+        ForegroundSyncController.markDeferredPeriodicSyncPending()
+
+        assertFalse(ForegroundSyncController.consumeDeferredPeriodicSyncIfReady())
+
+        ForegroundSyncController.updateReaderActive(false)
+        assertTrue(ForegroundSyncController.consumeDeferredPeriodicSyncIfReady())
+        assertFalse(ForegroundSyncController.consumeDeferredPeriodicSyncIfReady())
+    }
+
+    @Test
+    fun `deferred periodic sync is consumed after app leaves foreground`() {
+        ForegroundSyncController.updateAppInForeground(true)
+        ForegroundSyncController.updateReaderActive(true)
+        ForegroundSyncController.markDeferredPeriodicSyncPending()
+
+        ForegroundSyncController.updateAppInForeground(false)
+
+        assertTrue(ForegroundSyncController.consumeDeferredPeriodicSyncIfReady())
+    }
+}


### PR DESCRIPTION
## Summary
- defer periodic WorkManager sync runs while the in-app reader route is active in the foreground
- enqueue a deferred one-time sync when the user leaves the reader or the app leaves foreground
- add focused tests for the foreground sync deferral gate

Closes #106