### PR TITLE
[codex] Add swipe article navigation

### DIFF
--- a/app/src/main/java/me/ash/reader/infrastructure/preference/Preference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/Preference.kt
@@ -81,6 +81,7 @@ fun Preferences.toSettings(): Settings {
         hideEmptyGroups = HideEmptyGroupsPreference.fromPreferences(this),
         pullToSwitchFeed = PullToLoadNextFeedPreference.fromPreference(this),
         pullToSwitchArticle = PullToSwitchArticlePreference.fromPreference(this),
+        swipeToSwitchArticle = SwipeToSwitchArticlePreference.fromPreference(this),
         openLink = OpenLinkPreference.fromPreferences(this),
         openLinkSpecificBrowser = OpenLinkSpecificBrowserPreference.fromPreferences(this),
         sharedContent = SharedContentPreference.fromPreferences(this),

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/Settings.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/Settings.kt
@@ -74,6 +74,7 @@ data class Settings(
     val hideEmptyGroups: HideEmptyGroupsPreference = HideEmptyGroupsPreference.default,
     val pullToSwitchFeed: PullToLoadNextFeedPreference = PullToLoadNextFeedPreference.default,
     val pullToSwitchArticle: PullToSwitchArticlePreference = PullToSwitchArticlePreference.default,
+    val swipeToSwitchArticle: SwipeToSwitchArticlePreference = SwipeToSwitchArticlePreference.default,
     val openLink: OpenLinkPreference = OpenLinkPreference.default,
     val openLinkSpecificBrowser: OpenLinkSpecificBrowserPreference = OpenLinkSpecificBrowserPreference.default,
     val sharedContent: SharedContentPreference = SharedContentPreference.default,

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/SettingsProvider.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/SettingsProvider.kt
@@ -132,6 +132,7 @@ class SettingsProvider @Inject constructor(
             LocalMarkAsReadOnScroll provides settings.markAsReadOnScroll,
             LocalHideEmptyGroups provides settings.hideEmptyGroups,
             LocalPullToSwitchArticle provides settings.pullToSwitchArticle,
+            LocalSwipeToSwitchArticle provides settings.swipeToSwitchArticle,
             LocalOpenLink provides settings.openLink,
             LocalOpenLinkSpecificBrowser provides settings.openLinkSpecificBrowser,
             LocalSharedContent provides settings.sharedContent,

--- a/app/src/main/java/me/ash/reader/infrastructure/preference/SwipeToSwitchArticlePreference.kt
+++ b/app/src/main/java/me/ash/reader/infrastructure/preference/SwipeToSwitchArticlePreference.kt
@@ -1,0 +1,33 @@
+package me.ash.reader.infrastructure.preference
+
+import android.content.Context
+import androidx.compose.runtime.compositionLocalOf
+import androidx.datastore.preferences.core.Preferences
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import me.ash.reader.ui.ext.PreferencesKey
+import me.ash.reader.ui.ext.PreferencesKey.Companion.swipeToSwitchArticle
+import me.ash.reader.ui.ext.dataStore
+import me.ash.reader.ui.ext.put
+
+val LocalSwipeToSwitchArticle = compositionLocalOf { SwipeToSwitchArticlePreference.default }
+
+class SwipeToSwitchArticlePreference(val value: Boolean) : Preference() {
+    override fun put(context: Context, scope: CoroutineScope) {
+        scope.launch {
+            context.dataStore.put(PreferencesKey.swipeToSwitchArticle, value)
+        }
+    }
+
+    fun toggle(context: Context, scope: CoroutineScope) =
+        SwipeToSwitchArticlePreference(!value).put(context, scope)
+
+    companion object {
+        val default = SwipeToSwitchArticlePreference(false)
+        fun fromPreference(preference: Preferences): SwipeToSwitchArticlePreference {
+            return SwipeToSwitchArticlePreference(
+                preference[PreferencesKey.booleanKey(swipeToSwitchArticle)] ?: return default
+            )
+        }
+    }
+}

--- a/app/src/main/java/me/ash/reader/ui/component/webview/JavaScriptInterface.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/JavaScriptInterface.kt
@@ -10,6 +10,9 @@ interface JavaScriptInterface {
     @JavascriptInterface
     fun onLinkLongPress(url: String?, text: String?)
 
+    @JavascriptInterface
+    fun onHorizontalScrollableTouchStart(isScrollable: Boolean)
+
     companion object {
 
         const val NAME = "JavaScriptInterface"

--- a/app/src/main/java/me/ash/reader/ui/component/webview/RYWebView.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/RYWebView.kt
@@ -59,8 +59,7 @@ data class WebViewScrollSnapshot(
 
 /**
  * Custom WebView that detects horizontal gestures and tells parent views not to intercept.
- * This allows horizontal scrolling in code blocks to work smoothly without triggering
- * parent vertical scroll or page navigation.
+ * Only HTML elements that can actually scroll horizontally block parent interception.
  */
 class HorizontalScrollAwareWebView(context: Context) : WebView(context) {
     private var startX = 0f
@@ -72,6 +71,7 @@ class HorizontalScrollAwareWebView(context: Context) : WebView(context) {
     var onImageClick: ((imgUrl: String, altText: String) -> Unit)? = null
     var onLinkLongPress: ((url: String, text: String) -> Unit)? = null
     var handledScrollToTopRequest: Int = 0
+    var touchStartsInHorizontalScrollableContent: Boolean = false
 
     fun emitScrollSnapshot() {
         val maxScrollY = (computeVerticalScrollRange() - computeVerticalScrollExtent()).coerceAtLeast(0)
@@ -97,6 +97,7 @@ class HorizontalScrollAwareWebView(context: Context) : WebView(context) {
                 startX = event.x
                 startY = event.y
                 isHorizontalGesture = null
+                touchStartsInHorizontalScrollableContent = false
             }
             MotionEvent.ACTION_MOVE -> {
                 if (isHorizontalGesture == null) {
@@ -104,8 +105,7 @@ class HorizontalScrollAwareWebView(context: Context) : WebView(context) {
                     val dy = abs(event.y - startY)
                     if (dx > touchSlop || dy > touchSlop) {
                         isHorizontalGesture = dx > dy
-                        if (isHorizontalGesture == true) {
-                            // For horizontal gestures, tell parents not to intercept
+                        if (isHorizontalGesture == true && touchStartsInHorizontalScrollableContent) {
                             parent?.requestDisallowInterceptTouchEvent(true)
                         }
                     }
@@ -113,6 +113,7 @@ class HorizontalScrollAwareWebView(context: Context) : WebView(context) {
             }
             MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
                 isHorizontalGesture = null
+                touchStartsInHorizontalScrollableContent = false
             }
         }
         return super.dispatchTouchEvent(event)

--- a/app/src/main/java/me/ash/reader/ui/component/webview/RYWebView.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/RYWebView.kt
@@ -26,6 +26,7 @@ import androidx.compose.ui.unit.dp
 import androidx.compose.ui.viewinterop.AndroidView
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import java.util.concurrent.atomic.AtomicBoolean
 import kotlin.math.abs
 import me.ash.reader.infrastructure.preference.LocalOpenLink
 import me.ash.reader.infrastructure.preference.LocalOpenLinkSpecificBrowser
@@ -71,7 +72,22 @@ class HorizontalScrollAwareWebView(context: Context) : WebView(context) {
     var onImageClick: ((imgUrl: String, altText: String) -> Unit)? = null
     var onLinkLongPress: ((url: String, text: String) -> Unit)? = null
     var handledScrollToTopRequest: Int = 0
-    var touchStartsInHorizontalScrollableContent: Boolean = false
+    private val touchStartsInHorizontalScrollableContent = AtomicBoolean(false)
+
+    fun setTouchStartsInHorizontalScrollableContent(isScrollable: Boolean) {
+        touchStartsInHorizontalScrollableContent.set(isScrollable)
+        if (isScrollable) {
+            post {
+                if (isHorizontalGesture == true && touchStartsInHorizontalScrollableContent.get()) {
+                    parent?.requestDisallowInterceptTouchEvent(true)
+                }
+            }
+        }
+    }
+
+    fun resetTouchStartsInHorizontalScrollableContent() {
+        touchStartsInHorizontalScrollableContent.set(false)
+    }
 
     fun emitScrollSnapshot() {
         val maxScrollY = (computeVerticalScrollRange() - computeVerticalScrollExtent()).coerceAtLeast(0)
@@ -97,7 +113,7 @@ class HorizontalScrollAwareWebView(context: Context) : WebView(context) {
                 startX = event.x
                 startY = event.y
                 isHorizontalGesture = null
-                touchStartsInHorizontalScrollableContent = false
+                resetTouchStartsInHorizontalScrollableContent()
             }
             MotionEvent.ACTION_MOVE -> {
                 if (isHorizontalGesture == null) {
@@ -105,7 +121,7 @@ class HorizontalScrollAwareWebView(context: Context) : WebView(context) {
                     val dy = abs(event.y - startY)
                     if (dx > touchSlop || dy > touchSlop) {
                         isHorizontalGesture = dx > dy
-                        if (isHorizontalGesture == true && touchStartsInHorizontalScrollableContent) {
+                        if (isHorizontalGesture == true && touchStartsInHorizontalScrollableContent.get()) {
                             parent?.requestDisallowInterceptTouchEvent(true)
                         }
                     }
@@ -113,7 +129,7 @@ class HorizontalScrollAwareWebView(context: Context) : WebView(context) {
             }
             MotionEvent.ACTION_UP, MotionEvent.ACTION_CANCEL -> {
                 isHorizontalGesture = null
-                touchStartsInHorizontalScrollableContent = false
+                resetTouchStartsInHorizontalScrollableContent()
             }
         }
         return super.dispatchTouchEvent(event)

--- a/app/src/main/java/me/ash/reader/ui/component/webview/WebViewLayout.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/WebViewLayout.kt
@@ -157,9 +157,8 @@ object WebViewLayout {
 
                     @JavascriptInterface
                     override fun onHorizontalScrollableTouchStart(isScrollable: Boolean) {
-                        this@apply.touchStartsInHorizontalScrollableContent = isScrollable
-                        if (isScrollable) {
-                            this@apply.parent?.requestDisallowInterceptTouchEvent(true)
+                        this@apply.post {
+                            this@apply.touchStartsInHorizontalScrollableContent = isScrollable
                         }
                     }
                 },

--- a/app/src/main/java/me/ash/reader/ui/component/webview/WebViewLayout.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/WebViewLayout.kt
@@ -73,6 +73,7 @@ object WebViewLayout {
         webView.onImageClick = null
         webView.onLinkLongPress = null
         webView.handledScrollToTopRequest = 0
+        webView.touchStartsInHorizontalScrollableContent = false
         runCatching { webView.stopLoading() }
         runCatching { webView.loadUrl("about:blank") }
         runCatching { webView.onPause() }
@@ -151,6 +152,14 @@ object WebViewLayout {
                     override fun onLinkLongPress(url: String?, text: String?) {
                         if (url != null) {
                             this@apply.onLinkLongPress?.invoke(url, text ?: "")
+                        }
+                    }
+
+                    @JavascriptInterface
+                    override fun onHorizontalScrollableTouchStart(isScrollable: Boolean) {
+                        this@apply.touchStartsInHorizontalScrollableContent = isScrollable
+                        if (isScrollable) {
+                            this@apply.parent?.requestDisallowInterceptTouchEvent(true)
                         }
                     }
                 },

--- a/app/src/main/java/me/ash/reader/ui/component/webview/WebViewLayout.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/WebViewLayout.kt
@@ -73,7 +73,7 @@ object WebViewLayout {
         webView.onImageClick = null
         webView.onLinkLongPress = null
         webView.handledScrollToTopRequest = 0
-        webView.touchStartsInHorizontalScrollableContent = false
+        webView.resetTouchStartsInHorizontalScrollableContent()
         runCatching { webView.stopLoading() }
         runCatching { webView.loadUrl("about:blank") }
         runCatching { webView.onPause() }
@@ -157,9 +157,7 @@ object WebViewLayout {
 
                     @JavascriptInterface
                     override fun onHorizontalScrollableTouchStart(isScrollable: Boolean) {
-                        this@apply.post {
-                            this@apply.touchStartsInHorizontalScrollableContent = isScrollable
-                        }
+                        this@apply.setTouchStartsInHorizontalScrollableContent(isScrollable)
                     }
                 },
                 JavaScriptInterface.NAME,

--- a/app/src/main/java/me/ash/reader/ui/component/webview/WebViewScript.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/WebViewScript.kt
@@ -105,6 +105,38 @@ document.querySelectorAll("table").forEach(function(table) {
     wrapper.appendChild(table);
 });
 
+function isHorizontallyScrollableElement(element) {
+    if (!element || element === document.documentElement || element === document.body) {
+        return false;
+    }
+
+    const style = window.getComputedStyle(element);
+    const canOverflowX = /(auto|scroll|overlay)/.test(style.overflowX);
+    return canOverflowX && element.scrollWidth > element.clientWidth + 1;
+}
+
+function touchStartsInHorizontalScrollableContent(touch) {
+    if (!touch) {
+        return false;
+    }
+
+    let element = document.elementFromPoint(touch.clientX, touch.clientY);
+    while (element && element !== document.body) {
+        if (isHorizontallyScrollableElement(element)) {
+            return true;
+        }
+        element = element.parentElement;
+    }
+    return false;
+}
+
+document.addEventListener("touchstart", function(event) {
+    const isScrollable = touchStartsInHorizontalScrollableContent(event.touches && event.touches[0]);
+    if (window.${JavaScriptInterface.NAME} && window.${JavaScriptInterface.NAME}.onHorizontalScrollableTouchStart) {
+        window.${JavaScriptInterface.NAME}.onHorizontalScrollableTouchStart(isScrollable);
+    }
+}, { capture: true, passive: true });
+
 var images = document.querySelectorAll("img");
 
 images.forEach(function(img) {

--- a/app/src/main/java/me/ash/reader/ui/ext/DataStoreExt.kt
+++ b/app/src/main/java/me/ash/reader/ui/ext/DataStoreExt.kt
@@ -198,6 +198,7 @@ sealed interface PreferencesKey {
         const val hideEmptyGroups = "hideEmptyGroups"
         const val pullToLoadNextFeed = "pullToLoadNextFeed"
         const val pullToSwitchArticle = "pullToSwitchArticle"
+        const val swipeToSwitchArticle = "swipeToSwitchArticle"
         const val openLink = "openLink"
         const val openLinkAppSpecificBrowser = "openLinkAppSpecificBrowser"
         const val sharedContent = "sharedContent"
@@ -272,6 +273,7 @@ sealed interface PreferencesKey {
                 BooleanKey(hideEmptyGroups),
                 IntKey(pullToLoadNextFeed),
                 BooleanKey(pullToSwitchArticle),
+                BooleanKey(swipeToSwitchArticle),
                 IntKey(openLink),
                 StringKey(openLinkAppSpecificBrowser),
                 IntKey(sharedContent),

--- a/app/src/main/java/me/ash/reader/ui/page/home/reading/ReadingPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/reading/ReadingPage.kt
@@ -17,6 +17,10 @@ import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.ScrollState
+import androidx.compose.foundation.gestures.awaitEachGesture
+import androidx.compose.foundation.gestures.awaitFirstDown
+import androidx.compose.foundation.gestures.awaitHorizontalTouchSlopOrCancellation
+import androidx.compose.foundation.gestures.horizontalDrag
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
@@ -38,9 +42,14 @@ import androidx.compose.runtime.snapshotFlow
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.input.pointer.changedToUpIgnoreConsumed
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.input.pointer.positionChange
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalHapticFeedback
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalLayoutDirection
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.IntOffset
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
@@ -60,6 +69,7 @@ import me.ash.reader.infrastructure.android.TextToSpeechManager
 import me.ash.reader.infrastructure.preference.LocalPullToSwitchArticle
 import me.ash.reader.infrastructure.preference.LocalReadingAutoHideToolbar
 import me.ash.reader.infrastructure.preference.LocalReadingTextLineHeight
+import me.ash.reader.infrastructure.preference.LocalSwipeToSwitchArticle
 import me.ash.reader.ui.ext.collectAsStateValue
 import me.ash.reader.ui.ext.showToast
 import me.ash.reader.ui.page.adaptive.ArticleListReaderViewModel
@@ -91,6 +101,7 @@ fun ReadingPage(
     val hapticFeedback = LocalHapticFeedback.current
     val density = LocalDensity.current
     val isPullToSwitchArticleEnabled = LocalPullToSwitchArticle.current.value
+    val isSwipeToSwitchArticleEnabled = LocalSwipeToSwitchArticle.current.value
     val readingUiState = viewModel.readingUiState.collectAsStateValue()
     val readerState = viewModel.readerStateStateFlow.collectAsStateValue()
     val contentStateKey =
@@ -352,7 +363,25 @@ fun ReadingPage(
                                             )
                                         } else {
                                             Modifier
-                                        }
+                                        }.swipeToSwitchArticle(
+                                            enabled =
+                                                isSwipeToSwitchArticleEnabled &&
+                                                    !showFullScreenImageViewer &&
+                                                    !showLinkActionDialog &&
+                                                    !isVideoFullscreen,
+                                            canLoadPrevious = isPreviousArticleAvailable,
+                                            canLoadNext = isNextArticleAvailable,
+                                            onLoadPrevious = {
+                                                readerState.previousArticle?.let { (id, index) ->
+                                                    onLoadArticle(id, index)
+                                                }
+                                            },
+                                            onLoadNext = {
+                                                readerState.nextArticle?.let { (id, index) ->
+                                                    onLoadArticle(id, index)
+                                                }
+                                            },
+                                        )
                                         Content(
                                             modifier = contentModifier,
                                             contentPadding = paddings,
@@ -505,6 +534,59 @@ fun ReadingPage(
                         }
                     )
                 }
+            }
+        }
+    }
+}
+
+private enum class ArticleSwipeDirection {
+    Previous,
+    Next,
+}
+
+@Composable
+private fun Modifier.swipeToSwitchArticle(
+    enabled: Boolean,
+    canLoadPrevious: Boolean,
+    canLoadNext: Boolean,
+    onLoadPrevious: () -> Unit,
+    onLoadNext: () -> Unit,
+): Modifier {
+    if (!enabled) return this
+
+    val layoutDirection = LocalLayoutDirection.current
+    val thresholdPx = with(LocalDensity.current) { 96.dp.toPx() }
+
+    return pointerInput(enabled, canLoadPrevious, canLoadNext, layoutDirection, thresholdPx) {
+        awaitEachGesture {
+            val down = awaitFirstDown(requireUnconsumed = false)
+            var dragDistance = 0f
+            val drag =
+                awaitHorizontalTouchSlopOrCancellation(down.id) { change, overSlop ->
+                    dragDistance += overSlop
+                    change.consume()
+                } ?: return@awaitEachGesture
+
+            horizontalDrag(drag.id) { change ->
+                if (change.changedToUpIgnoreConsumed()) return@horizontalDrag
+                dragDistance += change.positionChange().x
+                change.consume()
+            }
+
+            if (abs(dragDistance) < thresholdPx) return@awaitEachGesture
+
+            val direction =
+                when {
+                    layoutDirection == LayoutDirection.Ltr && dragDistance < 0f ->
+                        ArticleSwipeDirection.Next
+                    layoutDirection == LayoutDirection.Ltr -> ArticleSwipeDirection.Previous
+                    dragDistance < 0f -> ArticleSwipeDirection.Previous
+                    else -> ArticleSwipeDirection.Next
+                }
+
+            when (direction) {
+                ArticleSwipeDirection.Previous -> if (canLoadPrevious) onLoadPrevious()
+                ArticleSwipeDirection.Next -> if (canLoadNext) onLoadNext()
             }
         }
     }

--- a/app/src/main/java/me/ash/reader/ui/page/home/reading/ReadingPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/home/reading/ReadingPage.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
 import androidx.compose.runtime.snapshotFlow
@@ -556,6 +557,8 @@ private fun Modifier.swipeToSwitchArticle(
 
     val layoutDirection = LocalLayoutDirection.current
     val thresholdPx = with(LocalDensity.current) { 96.dp.toPx() }
+    val currentOnLoadPrevious by rememberUpdatedState(onLoadPrevious)
+    val currentOnLoadNext by rememberUpdatedState(onLoadNext)
 
     return pointerInput(enabled, canLoadPrevious, canLoadNext, layoutDirection, thresholdPx) {
         awaitEachGesture {
@@ -585,8 +588,8 @@ private fun Modifier.swipeToSwitchArticle(
                 }
 
             when (direction) {
-                ArticleSwipeDirection.Previous -> if (canLoadPrevious) onLoadPrevious()
-                ArticleSwipeDirection.Next -> if (canLoadNext) onLoadNext()
+                ArticleSwipeDirection.Previous -> if (canLoadPrevious) currentOnLoadPrevious()
+                ArticleSwipeDirection.Next -> if (canLoadNext) currentOnLoadNext()
             }
         }
     }

--- a/app/src/main/java/me/ash/reader/ui/page/settings/color/reading/ReadingStylePage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/color/reading/ReadingStylePage.kt
@@ -45,6 +45,7 @@ import me.ash.reader.infrastructure.preference.LocalReadingBoldCharacters
 import me.ash.reader.infrastructure.preference.LocalReadingFonts
 import me.ash.reader.infrastructure.preference.LocalReadingPageTonalElevation
 import me.ash.reader.infrastructure.preference.LocalReadingTheme
+import me.ash.reader.infrastructure.preference.LocalSwipeToSwitchArticle
 import me.ash.reader.infrastructure.preference.ReadingFontsPreference
 import me.ash.reader.infrastructure.preference.ReadingPageTonalElevationPreference
 import me.ash.reader.infrastructure.preference.ReadingThemePreference
@@ -80,6 +81,7 @@ fun ReadingStylePage(
     val fonts = LocalReadingFonts.current
     val autoHideToolbar = LocalReadingAutoHideToolbar.current
     val pullToSwitchArticle = LocalPullToSwitchArticle.current
+    val swipeToSwitchArticle = LocalSwipeToSwitchArticle.current
     val boldCharacters = LocalReadingBoldCharacters.current
 
     var tonalElevationDialogVisible by remember { mutableStateOf(false) }
@@ -192,6 +194,13 @@ fun ReadingStylePage(
                         onClick = { pullToSwitchArticle.toggle(context, scope) }) {
                         RYSwitch(activated = pullToSwitchArticle.value, onClick = {
                             pullToSwitchArticle.toggle(context, scope)
+                        })
+                    }
+                    SettingItem(
+                        title = stringResource(id = R.string.swipe_to_switch_article),
+                        onClick = { swipeToSwitchArticle.toggle(context, scope) }) {
+                        RYSwitch(activated = swipeToSwitchArticle.value, onClick = {
+                            swipeToSwitchArticle.toggle(context, scope)
                         })
                     }
                     Subtitle(

--- a/app/src/main/java/me/ash/reader/ui/page/settings/interaction/InteractionPage.kt
+++ b/app/src/main/java/me/ash/reader/ui/page/settings/interaction/InteractionPage.kt
@@ -35,6 +35,7 @@ import me.ash.reader.infrastructure.preference.LocalPullToSwitchArticle
 import me.ash.reader.infrastructure.preference.LocalSettings
 import me.ash.reader.infrastructure.preference.LocalSharedContent
 import me.ash.reader.infrastructure.preference.LocalSortUnreadArticles
+import me.ash.reader.infrastructure.preference.LocalSwipeToSwitchArticle
 import me.ash.reader.infrastructure.preference.OpenLinkPreference
 import me.ash.reader.infrastructure.preference.PullToLoadNextFeedPreference
 import me.ash.reader.infrastructure.preference.SharedContentPreference
@@ -65,6 +66,7 @@ fun InteractionPage(
     val hideEmptyGroups = LocalHideEmptyGroups.current
     val sortUnreadArticles = LocalSortUnreadArticles.current
     val pullToSwitchArticle = LocalPullToSwitchArticle.current
+    val swipeToSwitchArticle = LocalSwipeToSwitchArticle.current
     val openLink = LocalOpenLink.current
     val openLinkSpecificBrowser = LocalOpenLinkSpecificBrowser.current
     val sharedContent = LocalSharedContent.current
@@ -196,6 +198,13 @@ fun InteractionPage(
                         onClick = { pullToSwitchArticle.toggle(context, scope) }) {
                         RYSwitch(activated = pullToSwitchArticle.value) {
                             pullToSwitchArticle.toggle(context, scope)
+                        }
+                    }
+                    SettingItem(
+                        title = stringResource(id = R.string.swipe_to_switch_article),
+                        onClick = { swipeToSwitchArticle.toggle(context, scope) }) {
+                        RYSwitch(activated = swipeToSwitchArticle.value) {
+                            swipeToSwitchArticle.toggle(context, scope)
                         }
                     }
                     Spacer(modifier = Modifier.height(24.dp))

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -321,6 +321,7 @@
     <string name="line_height_multiple">Line height multiple</string>
     <string name="export">Export</string>
     <string name="pull_to_switch_article">Pull to switch article</string>
+    <string name="swipe_to_switch_article">Swipe to switch article</string>
     <string name="mark_above_as_read">Mark above as read</string>
     <string name="mark_below_as_read">Mark below as read</string>
     <string name="marked_as_read">Marked as read</string>


### PR DESCRIPTION
## Summary

- Add a separate `Swipe to switch article` preference for the reading page.
- Handle previous/next article swipes at the reader page level, reusing the existing article loading path.
- Narrow WebView horizontal gesture interception so only horizontally scrollable HTML regions, such as wide tables or code blocks, keep the gesture.

Closes #31

## Validation

- `./gradlew :app:compileGithubDebugKotlin`
- `./gradlew :app:testGithubDebugUnitTest` failed because `DiffMapHolderUpdateDiffTest` has an unrelated invalid JUnit method signature: `Method explicit unread undo by ids participates in remote sync() should be void`.