### PR TITLE
fix(webview): keep video aspect ratio when inline style is stripped

### DIFF
--- a/app/src/main/java/me/ash/reader/ui/component/webview/WebViewStyle.kt
+++ b/app/src/main/java/me/ash/reader/ui/component/webview/WebViewStyle.kt
@@ -163,7 +163,8 @@ img {
     border-radius: var(--img-border-radius) !important;
 }
 
-img {
+img,
+video {
      height: auto !important;
 }
 


### PR DESCRIPTION
## Summary

Fixes video elements rendering as a tall portrait box with black bars top/bottom in the reader WebView.

 <img
  src="https://github.com/user-attachments/assets/cf81361f-01ac-4b26-9982-29af9648cf35"
  alt="Screenshot"
  height="700"
/>


## Root cause

Some feed backends (e.g. FreshRSS) sanitize feed HTML and strip inline `style` attributes for security. The simonwillison.net article video relies on its inline `style="height: auto"` to stay 16:9:

```html
<video width="1344" height="768" style="width:100%; height:auto;" preload="none">
```

Once the style is stripped, the browser falls back to the literal `height="768"` attribute while the injected CSS (`max-width: 100%`) caps the width to the article column. Result: a \~348×768 portrait box, with the 16:9 video letterboxed (black bars top/bottom).

`WebViewStyle.kt` already applies `height: auto !important` to `img`; `video` was missing from that rule.

## Fix

Add `video` to the existing auto-height rule so the element keeps its intrinsic aspect ratio (from `width`/`height` attributes or metadata) regardless of whether the site's inline style survives sanitization.

Verified: reproduces the portrait box (348×768) with the inline style stripped, and renders proper 16:9 after the fix.